### PR TITLE
Feat/testbed countries filter

### DIFF
--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -38,7 +38,7 @@ export function createCloudFrontDistribution(
                 cookies: {
                     forward: 'none',
                 },
-                queryString: false,
+                queryString: true,
             },
             minTtl: 0,
             defaultTtl: 2628000,

--- a/src/resources/external/ISO3166CountriesURL.ts
+++ b/src/resources/external/ISO3166CountriesURL.ts
@@ -1,5 +1,6 @@
 import Resource from '../../utils/data/models/Resource';
 import { getOutput } from '../../utils/data/parsers';
+import { isEnabledFilter } from '../../utils/filters';
 
 interface Country {
     id: string;
@@ -10,13 +11,21 @@ interface Country {
     threeLetterISORegionName: string;
 }
 
+async function fetchTestbedCountryIds(): Promise<string[]> {
+    const response = await fetch(
+        'https://raw.githubusercontent.com/Virtual-Finland/definitions/main/DataProducts/draft/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write.json'
+    );
+    const data = await response.json();
+    return data.components.schemas.ISO_3166_1_Alpha_3.enum;
+}
+
 export default new Resource({
     name: 'ISO3166CountriesURL',
     uri: 'https://github.com/mledoze/countries/blob/master/countries.json?raw=true',
     mime: 'application/json; charset=utf-8',
     parsers: {
-        async transform(countriesRaw: any) {
-            return countriesRaw.map((countryData: any) => {
+        async transform(countriesRaw: any, params: Record<string, string>) {
+            const countries = countriesRaw.map((countryData: any) => {
                 return {
                     id: countryData.cca2,
                     displayName: countryData.name.common,
@@ -26,6 +35,15 @@ export default new Resource({
                     threeLetterISORegionName: countryData.cca3,
                 };
             });
+
+            if (isEnabledFilter(params, 'testbed')) {
+                const TestbedCountryIds = await fetchTestbedCountryIds();
+                return countries.filter((country: Country) =>
+                    TestbedCountryIds.includes(country.threeLetterISORegionName)
+                );
+            }
+
+            return countries;
         },
         output(data: any) {
             return getOutput()<Country[]>(data); // Parse and stringify

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,7 @@
+export function isEnabledFilter(params: Record<string, string>, filterName: string): boolean {
+    if (typeof params.filters === 'string') {
+        const filters = params.filters.split(',');
+        return filters.includes(filterName);
+    }
+    return false;
+}


### PR DESCRIPTION
Allows the use of url query params in resource resolving.

Example filter pattern:
- return all: /resources/ISO3166CountriesURL
- return only known to testbed: /resources/ISO3166CountriesURL?filters=testbed

