### PR TITLE
feat: offset-limit -type pagination support for esco lists

### DIFF
--- a/src/utils/esco.ts
+++ b/src/utils/esco.ts
@@ -1,4 +1,4 @@
-import { getLocalesFilter, getSearchPhrases, isEnabledFormat } from './filters';
+import { getLocalesFilter, getPaginationParams, getSearchPhrases, isEnabledFormat } from './filters';
 
 export interface EscoDataUnit {
     uri: string;
@@ -41,8 +41,14 @@ export function filterCommonEscoDataSet<T extends EscoDataUnit>(items: T[], para
         });
     }
 
-    if (isEnabledFormat(params, 'tree')) {
-        items = formatToEscoTree<T>(items, params);
+    const pagination = getPaginationParams(params);
+    if (pagination.isPaginated) {
+        items = items.slice(pagination.offset, pagination.offset + pagination.limit);
+    } else {
+        // Pagination and tree-format is not compatible
+        if (isEnabledFormat(params, 'tree')) {
+            items = formatToEscoTree<T>(items, params);
+        }
     }
 
     return items;

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -27,3 +27,26 @@ export function getLocalesFilter(params: Record<string, string>): Array<string> 
     }
     return [];
 }
+
+export function getPaginationParams(params: Record<string, string>): {
+    isPaginated: boolean;
+    offset: number;
+    limit: number;
+} {
+    let offset = -1;
+    let limit = -1;
+
+    if (typeof params.offset !== 'undefined' && typeof params.limit !== 'undefined') {
+        offset = parseInt(params.offset);
+        limit = parseInt(params.limit);
+        if (!Number.isInteger(offset) || !Number.isInteger(limit)) {
+            throw new Error('Invalid pagination parameters');
+        }
+    }
+
+    return {
+        isPaginated: offset >= 0 && limit > 0,
+        offset,
+        limit,
+    };
+}


### PR DESCRIPTION
- sivutustoiminto esco-listoihin, mallia `offset-limit`. 
- tämän periaatteessa pitäisi toimia nykyisellään livenä cloudfrontin cachessa siten että aina ekan kerran kun "sivu" ladataan niin siinä kestää hetken pidempää, mutta tällä erää tiedon pienuuden vuoksi ei huomattavaa odottelua pitäisi syntyä. 

Paremmin käyttökeissit tulee tuolta esco-listojen data-space väännöstä, kunhan ne julkiannetaan, mutta toimintona tätäkin pitäisi voida testata käyttäen resurssia kuten normia GET-apia query-parametrein esim:

- `GET /resources/Occupations?offset=0&limit=1` -> [tulos 1]
- `GET /resources/Occupations?offset=1&limit=1` -> [tulos 2]

Mainittakoon ettei vastauksena tule kuin se lista arvoista, eli tässä oletusformaatissa ei tule esim. listan suuruudesta tietoja, mutta sellaisen formaatin vois kyhäillä ja varmaan pitääkin kyhäillä koska meillä on ehkä speksi.

Mainittakoon myös ettei paginaatiot ole käytössä/ei toimi jos käyttelee puumuotoa `formats=tree`.