### PR TITLE
feat: add uri redirector for special request paths

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1323.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1323.0.tgz",
-      "integrity": "sha512-GoLwk2SuG9A6eWgc1mGmm548dklheDmkeptHRw2RhCvq2GZqlc4AzStFUjUURy4O4NQmd2ZiQIoeseue4RwurA==",
+      "version": "2.1360.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1360.0.tgz",
+      "integrity": "sha512-wW1CviH1s6bl5+wO+KM7aSc3yy6cQPJT85Fd4rQgrn0uwfjg9fx7KJ0FRhv+eU4DabkRjcSMlKo1IGhARmT6Tw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -399,7 +399,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -1838,18 +1838,21 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
       }

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -30,8 +30,8 @@ export function createCloudFrontDistribution(
         ],
         customErrorResponses: [],
         defaultCacheBehavior: {
-            allowedMethods: ['GET', 'POST', 'HEAD', 'OPTIONS'],
-            cachedMethods: ['GET', 'POST', 'HEAD'],
+            allowedMethods: ['HEAD', 'DELETE', 'POST', 'GET', 'OPTIONS', 'PUT', 'PATCH'],
+            cachedMethods: ['GET', 'HEAD'],
             targetOriginId: bucket.arn,
             viewerProtocolPolicy: 'redirect-to-https',
             forwardedValues: {

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -30,8 +30,8 @@ export function createCloudFrontDistribution(
         ],
         customErrorResponses: [],
         defaultCacheBehavior: {
-            allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
-            cachedMethods: ['GET', 'HEAD'],
+            allowedMethods: ['GET', 'POST', 'HEAD', 'OPTIONS'],
+            cachedMethods: ['GET', 'POST', 'HEAD'],
             targetOriginId: bucket.arn,
             viewerProtocolPolicy: 'redirect-to-https',
             forwardedValues: {

--- a/infra/resources/S3Bucket.ts
+++ b/infra/resources/S3Bucket.ts
@@ -18,7 +18,7 @@ export default function createS3Bucket(setup: ISetup) {
         corsRules: [
             {
                 allowedHeaders: ['*'],
-                allowedMethods: ['GET'],
+                allowedMethods: ['GET', 'POST'],
                 allowedOrigins: ['*'],
             },
         ],
@@ -59,6 +59,15 @@ function publicReadPolicyForBucket(bucketName: string, originAccessArn: string, 
                 },
                 Action: 's3:GetObject',
                 Resource: `arn:aws:s3:::${bucketName}/*`,
+            },
+            {
+                Sid: 'PublicReadGetCachedObject',
+                Effect: 'Allow',
+                Principal: {
+                    AWS: ['*'],
+                },
+                Action: 's3:GetObject',
+                Resource: `arn:aws:s3:::${bucketName}/cached/*`,
             },
             {
                 Sid: 'WriteAccess',

--- a/infra/resources/S3Bucket.ts
+++ b/infra/resources/S3Bucket.ts
@@ -61,15 +61,6 @@ function publicReadPolicyForBucket(bucketName: string, originAccessArn: string, 
                 Resource: `arn:aws:s3:::${bucketName}/*`,
             },
             {
-                Sid: 'PublicReadGetCachedObject',
-                Effect: 'Allow',
-                Principal: {
-                    AWS: ['*'],
-                },
-                Action: 's3:GetObject',
-                Resource: `arn:aws:s3:::${bucketName}/cached/*`,
-            },
-            {
                 Sid: 'WriteAccess',
                 Effect: 'Allow',
                 Principal: {

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -17,8 +17,15 @@ test('Basic router test', async () => {
         ],
     } as CloudFrontRequestEvent;
     */
+
+    // Mock event
     const event = {
         rawPath: '/resources/bazz',
+        requestContext: {
+            http: {
+                method: 'GET',
+            },
+        },
     } as unknown as APIGatewayProxyEventV2;
 
     const result = (await offlineHandler(event)) as unknown as APIGatewayProxyStructuredResultV2;

--- a/src/app.ts
+++ b/src/app.ts
@@ -138,23 +138,23 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
                     routerResponse.cacheable.mime
                 );
                 uri = routerResponse.cacheable.filepath; // pass through to s3 origin
-
-                if (request.method === 'POST') {
-                    // If the request is POST, we need to use a redirect as origin does not support POST
-                    return {
-                        status: '302',
-                        statusDescription: 'Found',
-                        headers: {
-                            location: [
-                                {
-                                    key: 'Location',
-                                    value: uri,
-                                },
-                            ],
-                        },
-                    };
-                }
             }
+        }
+
+        if (request.method === 'POST') {
+            // If the request is POST, we need to use a redirect for the cache to work
+            return {
+                status: '302',
+                statusDescription: 'Found',
+                headers: {
+                    location: [
+                        {
+                            key: 'Location',
+                            value: uri,
+                        },
+                    ],
+                },
+            };
         }
 
         request.uri = uri; // Pass through to origin

--- a/src/app.ts
+++ b/src/app.ts
@@ -98,9 +98,9 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
         const request = event.Records[0].cf.request;
         let uri = resolveUri(request.uri);
         const params = Object.fromEntries(new URLSearchParams(request.querystring || ''));
-        if (request.method === 'POST' && typeof request.body === 'string') {
+        if (request.method === 'POST') {
             try {
-                const body = JSON.parse(request.body || '{}');
+                const body = JSON.parse(request.body?.data || '{}');
                 if (typeof body === 'object') {
                     Object.assign(params, body);
                 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import {
 } from 'aws-lambda';
 import mime from 'mime';
 import { InternalResources } from './resources/index';
+import { resolveUri } from './utils/UriResolver';
 import { getResource, listResources } from './utils/data/repositories/ResourceRepository';
 import { cutTooLongString, generateSimpleHash } from './utils/helpers';
 import { storeToS3 } from './utils/lib/S3Bucket';
@@ -96,7 +97,7 @@ async function engageResourcesRouter(
 export async function handler(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
     try {
         const request = event.Records[0].cf.request;
-        let uri = request.uri;
+        let uri = resolveUri(request.uri);
         const queryParams = request.querystring;
         console.log('Request: ', {
             uri,
@@ -153,7 +154,7 @@ export async function offlineHandler(event: APIGatewayProxyEventV2): Promise<API
         Environment.isLocal = true;
 
         const handle = async (event: APIGatewayProxyEventV2) => {
-            let uri = event.rawPath;
+            let uri = resolveUri(event.rawPath);
             const queryParams = event.rawQueryString;
             console.log('Request: ', {
                 uri,

--- a/src/app.ts
+++ b/src/app.ts
@@ -148,7 +148,7 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
                             location: [
                                 {
                                     key: 'Location',
-                                    value: `https://${bucketName}.s3.amazonaws.com${routerResponse.cacheable.filepath}`,
+                                    value: uri,
                                 },
                             ],
                         },

--- a/src/resources/internal/BusinessFinlandEscoOccupations.ts
+++ b/src/resources/internal/BusinessFinlandEscoOccupations.ts
@@ -2,6 +2,8 @@ import InternalResource from '../../utils/data/models/InternalResource';
 import { getOutput } from '../../utils/data/parsers';
 import { getPaginationParams } from '../../utils/filters';
 
+import BusinessFinlandDataSet from './business-finland-esco-v1_1_1-occupations.json';
+
 interface Occupation {
     escoCode: string;
     escoJobTitle: string;
@@ -34,5 +36,11 @@ export default new InternalResource({
         output(data: any) {
             return getOutput()<OccupationsResponse>(data);
         },
+    },
+    dataGetter() {
+        return Promise.resolve({
+            data: JSON.stringify(BusinessFinlandDataSet),
+            mime: 'application/json',
+        });
     },
 });

--- a/src/utils/UriResolver.ts
+++ b/src/utils/UriResolver.ts
@@ -1,7 +1,0 @@
-const UriRedirects: Record<string, string> = {
-    '/productizer/draft/Employment/EscoOccupations': '/resources/BusinessFinlandEscoOccupations',
-};
-
-export function resolveUri(uri: string): string {
-    return UriRedirects[uri] || uri;
-}

--- a/src/utils/UriResolver.ts
+++ b/src/utils/UriResolver.ts
@@ -1,0 +1,7 @@
+const UriRedirects: Record<string, string> = {
+    '/productizer/draft/Employment/EscoOccupations': '/resources/BusinessFinlandEscoOccupations',
+};
+
+export function resolveUri(uri: string): string {
+    return UriRedirects[uri] || uri;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,21 @@
+const UriRedirects: Record<string, string> = {
+    '/productizer/draft/Employment/EscoOccupations': '/resources/BusinessFinlandEscoOccupations',
+};
+
+export function resolveUri(uri: string): string {
+    return UriRedirects[uri] || uri;
+}
+
+export function resolveError(error: Error): { statusCode: number; body: string; description: string } {
+    const errorPackage = resolveErrorPackage(error);
+    console.error('Error: ', errorPackage);
+    return errorPackage;
+}
+
+function resolveErrorPackage(error: Error): { statusCode: number; body: string; description: string } {
+    return {
+        statusCode: 500,
+        description: 'Internal Server Error',
+        body: error.message || 'Internal Server Error',
+    };
+}

--- a/src/utils/data/models/InternalResource.ts
+++ b/src/utils/data/models/InternalResource.ts
@@ -3,6 +3,14 @@ import { retrieveFromS3 } from '../../lib/S3Bucket';
 import { Environment, getInternalResourceInfo } from '../../runtime';
 import BaseResource from './internal/BaseResource';
 
+const inMemoryCache: Record<
+    string,
+    {
+        data: string;
+        mime: string;
+    }
+> = {};
+
 export default class InternalResource extends BaseResource {
     public type = 'internal';
 
@@ -10,21 +18,29 @@ export default class InternalResource extends BaseResource {
         data: string;
         mime: string;
     }> {
+        if (typeof inMemoryCache[this.uri] !== 'undefined') {
+            console.log('Using in-memory cache for resource');
+            return inMemoryCache[this.uri];
+        }
+
         const fileName = this.uri;
 
         if (Environment.isLocal) {
             const resource = await InternalResources.getResourcePassThrough(fileName);
             if (resource) {
-                return {
+                inMemoryCache[this.uri] = {
                     data: resource.body,
                     mime: resource.mime || 'application/json',
                 };
+
+                return inMemoryCache[this.uri];
             }
             throw new Error(`Resource ${fileName} not found`);
         }
 
         const bucketName = getInternalResourceInfo().name;
         const bucketKey = `resources/${fileName}`;
-        return retrieveFromS3(bucketName, bucketKey);
+        inMemoryCache[this.uri] = await retrieveFromS3(bucketName, bucketKey);
+        return inMemoryCache[this.uri];
     }
 }

--- a/src/utils/data/models/internal/BaseResource.ts
+++ b/src/utils/data/models/internal/BaseResource.ts
@@ -56,20 +56,15 @@ export default class BaseResource implements IResource {
         mime: string;
         size: number;
     }> {
-        try {
-            this.validateSelf();
-            const dataPackage = await this._retrieveDataPackage(params);
-            const mime = this._mime || dataPackage.mime;
-            const finalData = await this._parseRawData(dataPackage.data, mime, params);
-            return {
-                data: finalData,
-                mime: mime,
-                size: Buffer.byteLength(finalData, 'utf8'),
-            };
-        } catch (error) {
-            console.log(error);
-            throw error;
-        }
+        this.validateSelf();
+        const dataPackage = await this._retrieveDataPackage(params);
+        const mime = this._mime || dataPackage.mime;
+        const finalData = await this._parseRawData(dataPackage.data, mime, params);
+        return {
+            data: finalData,
+            mime: mime,
+            size: Buffer.byteLength(finalData, 'utf8'),
+        };
     }
 
     private validateSelf(): void {

--- a/src/utils/data/models/internal/BaseResource.ts
+++ b/src/utils/data/models/internal/BaseResource.ts
@@ -20,9 +20,10 @@ export default class BaseResource implements IResource {
         input?: (data: string) => unknown;
         transform?: (data: unknown, params: Record<string, string>) => Promise<unknown>;
         output?: (data: unknown) => string;
-    } = {};
+    };
 
     protected _dataGetter: ((params: Record<string, string>) => Promise<{ data: string; mime: string }>) | undefined;
+    protected _settings: Record<string, string | number | boolean>;
 
     constructor({
         name,
@@ -31,6 +32,7 @@ export default class BaseResource implements IResource {
         type,
         dataGetter,
         parsers,
+        settings,
     }: {
         name: string;
         type?: 'external' | 'library' | 'internal';
@@ -42,6 +44,7 @@ export default class BaseResource implements IResource {
             transform?: (data: unknown, params: Record<string, string>) => Promise<unknown>; // Data intake -> transformed data
             output?: (data: unknown) => string; // Transformed data intake -> raw output data
         };
+        settings?: Record<string, string | number | boolean>;
     }) {
         this.name = name;
         this.uri = uri || '';
@@ -49,6 +52,7 @@ export default class BaseResource implements IResource {
         this._mime = mime;
         this._dataGetter = dataGetter;
         this._parsers = parsers || {};
+        this._settings = settings || {};
     }
 
     public async retrieve(params: Record<string, string>): Promise<{

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -37,10 +37,11 @@ export function getPaginationParams(params: Record<string, string>): {
     let limit = -1;
 
     if (typeof params.offset !== 'undefined' && typeof params.limit !== 'undefined') {
-        offset = parseInt(params.offset);
-        limit = parseInt(params.limit);
-        if (!Number.isInteger(offset) || !Number.isInteger(limit)) {
-            throw new Error('Invalid pagination parameters');
+        const parsedOffset = parseInt(params.offset);
+        const parsedLimit = parseInt(params.limit);
+        if (Number.isInteger(parsedOffset) && Number.isInteger(parsedLimit)) {
+            offset = parsedOffset;
+            limit = parsedLimit;
         }
     }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -72,3 +72,12 @@ export function omitObjectKeys(object: any, keys: string[]): any {
 export function decodeBase64(str: string): string {
     return Buffer.from(str, 'base64').toString('utf-8');
 }
+
+/**
+ *
+ * @param body
+ * @returns
+ */
+export function parseRequestInputParams(body: any): Record<string, string> {
+    return Object.entries(body).reduce((acc, [key, value]) => ({ ...acc, [key]: String(value) }), {});
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -63,3 +63,12 @@ export function omitObjectKeys(object: any, keys: string[]): any {
     });
     return result;
 }
+
+/**
+ *
+ * @param str
+ * @returns
+ */
+export function decodeBase64(str: string): string {
+    return Buffer.from(str, 'base64').toString('utf-8');
+}


### PR DESCRIPTION
- redirect requests: `/productizer/draft/Employment/EscoOccupations` -> `/resources/BusinessFinlandEscoOccupations`
- support for POST requests

Testable at testbed gw: `https://gateway.testbed.fi/draft/Employment/EscoOccupations?source=virtual_finland:development`

eg:

```
curl -X 'POST' \
  'https://gateway.testbed.fi/draft/Employment/EscoOccupations?source=virtual_finland%3Adevelopment' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "limit": 10,
  "offset": 0
}'
```