### PR TITLE
Feature/save standard logs to s3

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -29,4 +29,8 @@ export const url = pulumi.interpolate`https://${cloudFrontDistribution.domainNam
 export const bucketName = s3bucketSetup.bucket.bucket;
 export const lambdaId = pulumi.interpolate`${edgeLambdaPackage.lambdaAtEdgeFunction.name}:${edgeLambdaPackage.lambdaAtEdgeFunction.version}`
 export const cloudFrontDistributionId = cloudFrontDistribution.id;
-export const standardLogsBucketName = standardLogsBucket.bucket;
+export const standardLogsBucketDetails = {
+    name: standardLogsBucket.bucket,
+    arn: standardLogsBucket.arn,
+    id: standardLogsBucket.id
+}

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -5,19 +5,22 @@ import {
     createOriginAccessIdentity,
 } from './resources/CloudFront';
 import createLambdaAtEdgeFunction from './resources/LambdaAtEdge';
-import createS3Bucket, { createS3BucketPermissions, uploadAssetsToBucket } from './resources/S3Bucket';
-import { getSetup } from './utils/Setup';
+import createS3Bucket, {createS3BucketPermissions, uploadAssetsToBucket} from './resources/S3Bucket';
+import {getSetup} from './utils/Setup';
+import {createStandardLogsBucket} from "./resources/standardLogsBucket";
 
 const setup = getSetup();
 const originAccessIdentity = createOriginAccessIdentity(setup);
 const s3bucketSetup = createS3Bucket(setup);
 const edgeLambdaPackage = createLambdaAtEdgeFunction(setup, s3bucketSetup);
 createS3BucketPermissions(setup, s3bucketSetup.bucket, originAccessIdentity, edgeLambdaPackage.lambdaAtEdgeRole);
+const standardLogsBucket = createStandardLogsBucket(setup);
 const cloudFrontDistribution = createCloudFrontDistribution(
     setup,
     s3bucketSetup.bucket,
     originAccessIdentity,
-    edgeLambdaPackage.lambdaAtEdgeFunction
+    edgeLambdaPackage.lambdaAtEdgeFunction,
+    standardLogsBucket
 );
 uploadAssetsToBucket(s3bucketSetup.bucket);
 createCacheInvalidation(setup, cloudFrontDistribution);

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -30,7 +30,6 @@ export const bucketName = s3bucketSetup.bucket.bucket;
 export const lambdaId = pulumi.interpolate`${edgeLambdaPackage.lambdaAtEdgeFunction.name}:${edgeLambdaPackage.lambdaAtEdgeFunction.version}`
 export const cloudFrontDistributionId = cloudFrontDistribution.id;
 export const standardLogsBucketDetails = {
-    name: standardLogsBucket.bucket,
     arn: standardLogsBucket.arn,
     id: standardLogsBucket.id
 }

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -29,3 +29,4 @@ export const url = pulumi.interpolate`https://${cloudFrontDistribution.domainNam
 export const bucketName = s3bucketSetup.bucket.bucket;
 export const lambdaId = pulumi.interpolate`${edgeLambdaPackage.lambdaAtEdgeFunction.name}:${edgeLambdaPackage.lambdaAtEdgeFunction.version}`
 export const cloudFrontDistributionId = cloudFrontDistribution.id;
+export const standardLogsBucketName = standardLogsBucket.bucket;

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -14,7 +14,8 @@ export function createCloudFrontDistribution(
     setup: ISetup,
     bucket: aws.s3.Bucket,
     originAccessIdentity: aws.cloudfront.OriginAccessIdentity,
-    lambdaAtEdgeFunction: aws.lambda.Function
+    lambdaAtEdgeFunction: aws.lambda.Function,
+    standardLogsBucket: aws.s3.Bucket
 ) {
     const cloudFrontDistributionConfig = setup.getResourceConfig('CloudFrontDistribution');
 
@@ -69,6 +70,11 @@ export function createCloudFrontDistribution(
         enabled: true,
         retainOnDelete: false,
         tags: cloudFrontDistributionConfig.tags,
+        loggingConfig: {
+            bucket: standardLogsBucket.arn,
+            prefix: '',
+            includeCookies: false,
+        }
     });
 
     // Extended monitoring

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -72,7 +72,7 @@ export function createCloudFrontDistribution(
         tags: cloudFrontDistributionConfig.tags,
         loggingConfig: {
             bucket: standardLogsBucket.arn,
-            prefix: '',
+            prefix: 'std-cf-logs',
             includeCookies: false,
         }
     });

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -71,7 +71,7 @@ export function createCloudFrontDistribution(
         retainOnDelete: false,
         tags: cloudFrontDistributionConfig.tags,
         loggingConfig: {
-            bucket: standardLogsBucket.bucket,
+            bucket: standardLogsBucket.bucketDomainName,
             prefix: 'std-cf-logs',
             includeCookies: false,
         }

--- a/infra/resources/CloudFront.ts
+++ b/infra/resources/CloudFront.ts
@@ -71,7 +71,7 @@ export function createCloudFrontDistribution(
         retainOnDelete: false,
         tags: cloudFrontDistributionConfig.tags,
         loggingConfig: {
-            bucket: standardLogsBucket.arn,
+            bucket: standardLogsBucket.bucket,
             prefix: 'std-cf-logs',
             includeCookies: false,
         }

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -3,16 +3,17 @@ import {Bucket} from "@pulumi/aws/s3";
 import {ISetup} from "../utils/Setup";
 
 export function createStandardLogsBucket(setup: ISetup): Bucket {
-    return new aws.s3.Bucket("standard-logs-bucket", {
+    return new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
         lifecycleRules: [
             {
                 enabled: true,
                 expiration: {
                     days: 2
                 },
-                id: "standard-logs-expiration-rule"
+                id: `standard-logs-expiration-rule-${setup.stage}`
             }
         ],
+        acl: 'private',
         tags: setup.getResourceConfig('standard-logs-bucket').tags
     });
 }

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -3,6 +3,7 @@ import {Bucket} from "@pulumi/aws/s3";
 import {ISetup} from "../utils/Setup";
 
 export function createStandardLogsBucket(setup: ISetup): Bucket {
+    const awsEuNorth1 = new aws.Provider("aws-eu-north-1", { region: "eu-north-1" });
     const bucket = new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
         lifecycleRules: [
             {
@@ -15,6 +16,8 @@ export function createStandardLogsBucket(setup: ISetup): Bucket {
         ],
         acl: 'private',
         tags: setup.getResourceConfig('standard-logs-bucket').tags
+    }, {
+        provider: awsEuNorth1
     });
     
     const bucketOwnershipControls = new aws.s3.BucketOwnershipControls('controls', {

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -1,0 +1,18 @@
+import * as aws from "@pulumi/aws";
+import {Bucket} from "@pulumi/aws/s3";
+import {ISetup} from "../utils/Setup";
+
+export function createStandardLogsBucket(setup: ISetup): Bucket {
+    return new aws.s3.Bucket("standard-logs-bucket", {
+        lifecycleRules: [
+            {
+                enabled: true,
+                expiration: {
+                    days: 2
+                },
+                id: "standard-logs-expiration-rule"
+            }
+        ],
+        tags: setup.getResourceConfig('standard-logs-bucket').tags
+    });
+}

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -25,6 +25,8 @@ export function createStandardLogsBucket(setup: ISetup): Bucket {
         rule: {
             objectOwnership: "BucketOwnerPreferred"
         }
+    }, {
+        provider: awsEuNorth1
     });
 
     return bucket;

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -3,7 +3,7 @@ import {Bucket} from "@pulumi/aws/s3";
 import {ISetup} from "../utils/Setup";
 
 export function createStandardLogsBucket(setup: ISetup): Bucket {
-    return new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
+    const bucket = new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
         lifecycleRules: [
             {
                 enabled: true,
@@ -16,4 +16,13 @@ export function createStandardLogsBucket(setup: ISetup): Bucket {
         acl: 'private',
         tags: setup.getResourceConfig('standard-logs-bucket').tags
     });
+    
+    const bucketOwnershipControls = new aws.s3.BucketOwnershipControls('controls', {
+       bucket: bucket.id,
+       rule: {
+           objectOwnership: "BucketOwnerPreferred"
+       } 
+    });
+    
+    return bucket;
 }

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -4,7 +4,7 @@ import {ISetup} from "../utils/Setup";
 
 export function createStandardLogsBucket(setup: ISetup): Bucket {
     const awsEuNorth1 = new aws.Provider("aws-eu-north-1", {region: "eu-north-1"});
-    const bucket = new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
+    const bucket = new aws.s3.Bucket(`${setup.projectName}-standard-logs-${setup.stage}`, {
         lifecycleRules: [
             {
                 enabled: true,

--- a/infra/resources/standardLogsBucket.ts
+++ b/infra/resources/standardLogsBucket.ts
@@ -3,7 +3,7 @@ import {Bucket} from "@pulumi/aws/s3";
 import {ISetup} from "../utils/Setup";
 
 export function createStandardLogsBucket(setup: ISetup): Bucket {
-    const awsEuNorth1 = new aws.Provider("aws-eu-north-1", { region: "eu-north-1" });
+    const awsEuNorth1 = new aws.Provider("aws-eu-north-1", {region: "eu-north-1"});
     const bucket = new aws.s3.Bucket(`standard-logs-bucket-${setup.stage}`, {
         lifecycleRules: [
             {
@@ -19,13 +19,13 @@ export function createStandardLogsBucket(setup: ISetup): Bucket {
     }, {
         provider: awsEuNorth1
     });
-    
+
     const bucketOwnershipControls = new aws.s3.BucketOwnershipControls('controls', {
-       bucket: bucket.id,
-       rule: {
-           objectOwnership: "BucketOwnerPreferred"
-       } 
+        bucket: bucket.id,
+        rule: {
+            objectOwnership: "BucketOwnerPreferred"
+        }
     });
-    
+
     return bucket;
 }


### PR DESCRIPTION
Konffataan CloudFront tallentamaan logit S3 ämpäriin, mistä logit voidaan prosessoida Lambdan avulla CloudWatchiin. 

Logien prosessointi on toteutettu haaralla:
https://github.com/Virtual-Finland-Development/monitoring/tree/feature/create-log-forwarder-for-cloudfront