### PR TITLE
Stabilize EscoAPI cache performance

### DIFF
--- a/src/escoApi.ts
+++ b/src/escoApi.ts
@@ -1,8 +1,14 @@
 import { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda';
-import { UriRedirects, resolveError } from './utils/api';
+import { resolveError } from './utils/api';
+import { transformOccupations } from './utils/data/transformers';
 import { ValidationError } from './utils/exceptions';
 
 const CODESETS_API_ENDPOINT = process.env.CODESETS_API_ENDPOINT;
+
+// Store for the duration of the lambda instance
+const internalMemory = {
+    responseData: null,
+};
 
 // AWS Lambda function handler for the ESCO API
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
@@ -17,21 +23,21 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
     // Normal request handling
     try {
         const request = parseRequest(event);
-
-        const paramsAsQuery = new URLSearchParams(request.params).toString();
         const uri = `${CODESETS_API_ENDPOINT}${request.path}`;
-        const uriAsQuery = uri + (paramsAsQuery ? '?' + paramsAsQuery : '');
-        const response = await fetch(uriAsQuery);
-        const responseBody = await response.text();
 
-        const responseHeaders = Object.entries(response.headers).reduce((headers, [key, value]) => {
-            headers[key] = value;
-            return headers;
-        }, {} as Record<string, string>);
+        if (internalMemory.responseData === null) {
+            const response = await fetch(uri);
+            internalMemory.responseData = await response.json();
+        }
+
+        const transformedData = transformOccupations(internalMemory.responseData, request.params);
+        const responseBody = JSON.stringify(transformedData);
 
         return {
-            statusCode: response.status,
-            headers: responseHeaders,
+            statusCode: 200,
+            headers: {
+                'Content-Type': 'application/json',
+            },
             body: responseBody,
         };
     } catch (error: any) {
@@ -59,7 +65,7 @@ function parseRequest(event: APIGatewayProxyEventV2): { method: string; path: st
         throw new ValidationError('Missing request body');
     }
 
-    const knownPaths = Object.keys(UriRedirects);
+    const knownPaths = ['/productizer/draft/Employment/EscoOccupations'];
     if (!knownPaths.includes(rawPath)) {
         throw new ValidationError('Unknown request path');
     }

--- a/src/resources/internal/BusinessFinlandEscoOccupations.ts
+++ b/src/resources/internal/BusinessFinlandEscoOccupations.ts
@@ -1,6 +1,6 @@
 import InternalResource from '../../utils/data/models/InternalResource';
 import { getOutput } from '../../utils/data/parsers';
-import { getPaginationParams } from '../../utils/filters';
+import { transformOccupations as transform } from '../../utils/data/transformers';
 
 import BusinessFinlandDataSet from './business-finland-esco-v1_1_1-occupations.json';
 
@@ -21,18 +21,7 @@ export default new InternalResource({
     name: 'BusinessFinlandEscoOccupations',
     uri: 'business-finland-esco-v1_1_1-occupations.json',
     parsers: {
-        async transform(occupations: any, params: Record<string, string>) {
-            const totalCount = occupations.length;
-            const pagination = getPaginationParams(params);
-            if (pagination.isPaginated) {
-                occupations = occupations.slice(pagination.offset, pagination.offset + pagination.limit);
-            }
-
-            return {
-                totalCount: totalCount,
-                occupations: occupations,
-            };
-        },
+        transform,
         output(data: any) {
             return getOutput()<OccupationsResponse>(data);
         },

--- a/src/utils/data/transformers.ts
+++ b/src/utils/data/transformers.ts
@@ -1,0 +1,21 @@
+import { getPaginationParams } from '../filters';
+
+/**
+ * Separate occupations transformer from the resource to avoid resource-related dependencies import where not needed
+ *
+ * @param occupations
+ * @param params
+ * @returns
+ */
+export async function transformOccupations(occupations: any, params: Record<string, string>) {
+    const totalCount = occupations.length;
+    const pagination = getPaginationParams(params);
+    if (pagination.isPaginated) {
+        occupations = occupations.slice(pagination.offset, pagination.offset + pagination.limit);
+    }
+
+    return {
+        totalCount: totalCount,
+        occupations: occupations,
+    };
+}


### PR DESCRIPTION
- Instead of paginated results, load all of data from cloudfront cache
  - previously cache hit would depend on the pagination params (as url query param match): every request cached separately
  - now all data is cached in one go: every request just as fast as the other: eg. page 1 should be as fast as page 2, switching from pagesize 10 to 15 should no longer affect the first time query response time
- Implement pagination on the escoapi-side