### PR TITLE
build: use provisioned concurrency as lambda heater method

### DIFF
--- a/infra/utils/Setup.ts
+++ b/infra/utils/Setup.ts
@@ -14,7 +14,7 @@ const setup = {
         };
     },
     isProductionLikeEnvironment() {
-        return this.stage === 'production' || this.stage === 'staging';
+        return this.stage.endsWith('production') || this.stage.endsWith('staging');
     },
 };
 
@@ -23,4 +23,5 @@ function getSetup() {
     return setup;
 }
 
-export { getSetup, ISetup };
+export { ISetup, getSetup };
+

--- a/src/escoApi.ts
+++ b/src/escoApi.ts
@@ -12,15 +12,6 @@ const internalMemory: any = {
 
 // AWS Lambda function handler for the ESCO API
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-    // Lambda warmup request handling
-    if ((event as any)?.source === 'warmup') {
-        return {
-            statusCode: 200,
-            body: 'Warmup successful',
-        };
-    }
-
-    // Normal request handling
     try {
         const request = parseRequest(event);
         const uri = `${CODESETS_API_ENDPOINT}${request.path}`;


### PR DESCRIPTION
- warmup method changed to provisioned concurrency as the cheap warmup pollutes logs