### PR TITLE
Refactor runtime settings to app handler initiated instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.391.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.391.0.tgz",
@@ -1007,17 +1019,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/url-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.3.tgz",
@@ -1294,6 +1295,30 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.363.0",
       "dev": true,
@@ -1341,6 +1366,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.363.0",
       "dev": true,
@@ -1349,6 +1386,18 @@
         "@aws-sdk/types": "3.357.0",
         "@smithy/property-provider": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1369,6 +1418,18 @@
         "@smithy/property-provider": "^1.0.1",
         "@smithy/shared-ini-file-loader": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1396,6 +1457,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.363.0",
       "dev": true,
@@ -1405,6 +1478,18 @@
         "@smithy/property-provider": "^1.0.1",
         "@smithy/shared-ini-file-loader": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1428,6 +1513,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.363.0",
       "dev": true,
@@ -1436,6 +1533,18 @@
         "@aws-sdk/types": "3.357.0",
         "@smithy/property-provider": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1476,17 +1585,6 @@
       "integrity": "sha512-yzBYloviSLOwo2RT62vBRCPtk8mc/O2RMJfynEahbX8ZnduHpKaajvx3IuGubhamIbesi7M5HBVecDehBnlb9Q==",
       "dependencies": {
         "@smithy/types": "^2.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1536,17 +1634,6 @@
       "integrity": "sha512-yzBYloviSLOwo2RT62vBRCPtk8mc/O2RMJfynEahbX8ZnduHpKaajvx3IuGubhamIbesi7M5HBVecDehBnlb9Q==",
       "dependencies": {
         "@smithy/types": "^2.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1606,17 +1693,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
@@ -1655,6 +1731,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.391.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.391.0.tgz",
@@ -1680,17 +1768,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.363.0",
       "dev": true,
@@ -1698,6 +1775,18 @@
       "dependencies": {
         "@aws-sdk/types": "3.357.0",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1712,6 +1801,18 @@
         "@aws-sdk/types": "3.357.0",
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1757,17 +1858,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.363.0",
       "dev": true,
@@ -1776,6 +1866,18 @@
         "@aws-sdk/middleware-signing": "3.363.0",
         "@aws-sdk/types": "3.357.0",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1793,6 +1895,18 @@
         "@smithy/signature-v4": "^1.0.1",
         "@smithy/types": "^1.1.0",
         "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1824,17 +1938,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.363.0",
       "dev": true,
@@ -1844,6 +1947,18 @@
         "@aws-sdk/util-endpoints": "3.357.0",
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1937,17 +2052,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/util-buffer-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
@@ -2021,6 +2125,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/types": {
       "version": "3.357.0",
       "license": "Apache-2.0",
@@ -2075,6 +2191,18 @@
         "tslib": "^2.5.0"
       }
     },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.363.0",
       "dev": true,
@@ -2095,6 +2223,18 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -3830,6 +3970,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
@@ -3896,6 +4048,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "1.0.1",
       "dev": true,
@@ -3905,6 +4069,18 @@
         "@smithy/property-provider": "^1.0.1",
         "@smithy/types": "^1.1.0",
         "@smithy/url-parser": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3922,6 +4098,18 @@
         "tslib": "^2.5.0"
       }
     },
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "1.0.1",
       "dev": true,
@@ -3935,12 +4123,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "1.0.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3960,6 +4172,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/eventstream-serde-universal": {
       "version": "1.0.1",
       "dev": true,
@@ -3967,6 +4191,18 @@
       "dependencies": {
         "@smithy/eventstream-codec": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3985,6 +4221,18 @@
         "tslib": "^2.5.0"
       }
     },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/hash-blob-browser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.3.tgz",
@@ -3996,17 +4244,6 @@
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/hash-node": {
       "version": "1.0.1",
       "dev": true,
@@ -4015,6 +4252,18 @@
         "@smithy/types": "^1.1.0",
         "@smithy/util-buffer-from": "^1.0.1",
         "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4038,17 +4287,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4089,6 +4327,18 @@
         "tslib": "^2.5.0"
       }
     },
+    "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/is-array-buffer": {
       "version": "1.0.1",
       "dev": true,
@@ -4114,17 +4364,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4169,6 +4408,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "1.0.2",
       "dev": true,
@@ -4178,6 +4429,18 @@
         "@smithy/types": "^1.1.0",
         "@smithy/url-parser": "^1.0.1",
         "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4201,6 +4464,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/middleware-retry/node_modules/uuid": {
       "version": "8.3.2",
       "dev": true,
@@ -4215,6 +4490,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4246,6 +4533,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/node-http-handler": {
       "version": "1.0.2",
       "dev": true,
@@ -4255,6 +4554,18 @@
         "@smithy/protocol-http": "^1.1.0",
         "@smithy/querystring-builder": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4273,12 +4584,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/protocol-http": {
       "version": "1.1.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4298,12 +4633,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/querystring-parser": {
       "version": "1.0.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4330,6 +4689,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/signature-v4": {
       "version": "1.0.1",
       "dev": true,
@@ -4342,6 +4713,18 @@
         "@smithy/util-middleware": "^1.0.1",
         "@smithy/util-uri-escape": "^1.0.1",
         "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4362,10 +4745,22 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/types": {
-      "version": "1.1.0",
+    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.1.tgz",
+      "integrity": "sha512-6nyDOf027ZeJiQVm6PXmLm7dR+hR2YJUkr4VwUniXA8xZUGAu5Mk0zfx2BPFrt+e5YauvlIqQoH0CsrM4tLkfg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4381,6 +4776,18 @@
         "@smithy/querystring-parser": "^1.0.1",
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-base64": {
@@ -4451,6 +4858,18 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "1.0.1",
       "dev": true,
@@ -4465,6 +4884,18 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
@@ -4519,6 +4950,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/util-uri-escape": {
       "version": "1.0.1",
       "dev": true,
@@ -4549,6 +4992,18 @@
       "dependencies": {
         "@smithy/abort-controller": "^1.0.1",
         "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
     "eslint-config-prettier": "^8.7.0",
     "jest": "^29.4.3",
     "nodemon": "^3.0.1",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "serverless-offline": "^12.0.4",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5",
-    "npm-run-all": "^4.1.5"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.383.0",
@@ -63,7 +63,7 @@
     "iso-3166": "^4.2.0",
     "iso-639": "^0.2.2",
     "mime": "^3.0.0",
-    "valibot": "^0.8.0",
-    "ts-mixer": "^6.0.3"
+    "ts-mixer": "^6.0.3",
+    "valibot": "^0.8.0"
   }
 }

--- a/src/app/RequestApp.ts
+++ b/src/app/RequestApp.ts
@@ -1,0 +1,21 @@
+import { APIGatewayProxyEventV2, CloudFrontRequestEvent } from "aws-lambda";
+import { IStorage } from "../utils/lib/IStorage";
+import LocalMemoryStorage from "../utils/lib/LocalMemoryStorage";
+import { RuntimeFlags } from "../utils/runtime";
+import RequestLogger, { RequestLoggerSettings } from "./RequestLogger";
+
+export default class RequestApp {
+    logger: RequestLogger; // Access to request logger
+    storage: IStorage; // Access to primary storage
+    runtimeFlags: typeof RuntimeFlags; // Access to static runtime flags object
+
+    constructor(request: APIGatewayProxyEventV2 | CloudFrontRequestEvent, setup?: { storage?: IStorage, loggerSettings?: RequestLoggerSettings, runtimeFlags?: typeof RuntimeFlags }) {
+        this.logger = new RequestLogger(request, setup?.loggerSettings);
+        this.storage = setup?.storage || new LocalMemoryStorage();
+        if (setup?.runtimeFlags) {
+            // Merge runtime flags
+            Object.assign(RuntimeFlags, setup.runtimeFlags);
+        }
+        this.runtimeFlags = RuntimeFlags; // Pass a reference
+    }
+}

--- a/src/app/RequestLogger.ts
+++ b/src/app/RequestLogger.ts
@@ -1,6 +1,5 @@
 import { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2, CloudFrontHeaders, CloudFrontRequestEvent, CloudFrontRequestResult, CloudFrontResultResponse } from "aws-lambda";
 import { ValiError } from "valibot";
-import { cutTooLongString } from "../utils/helpers";
 
 export type LogPackage = {
     trace: {
@@ -17,8 +16,8 @@ export type LogPackage = {
     response: {
         statusCode: number;
         contentLength: number;
-        body?: string; // For error diagnostics
     };
+    errors: any[],
 };
 
 export type RequestLoggerSettings = {
@@ -30,7 +29,7 @@ export type RequestLoggerSettings = {
 export default class RequestLogger {
     private readonly request: APIGatewayProxyEventV2 | CloudFrontRequestEvent;
     private readonly configuration: RequestLoggerSettings;
-    private readonly errors: string[] = [];
+    private readonly errors: any[] = [];
 
     constructor(request: APIGatewayProxyEventV2 | CloudFrontRequestEvent, configuration?: RequestLoggerSettings) {
         this.request = request;
@@ -45,20 +44,17 @@ export default class RequestLogger {
         }
 
         if (typeof log.response.statusCode !== "number" || log.response.statusCode >= 400) {
-            log.response.body = cutTooLongString(log.response.body, 1000); // Limit logged body length to 1000 characters
-            console.error(JSON.stringify(log));
-            console.debug(JSON.stringify(this.errors));
+            console.error(JSON.stringify(log, null, 4));
         } else {
-            delete log.response.body; // Remove body from successful requests logs
             console.log(JSON.stringify(log));
         }
     }
 
-    public catchError(error: any) {
+    public catchError(error: Error | ValiError | any) {
         if (error instanceof ValiError)  {
             // Cleanup the vali error to make it more accessible: only show the first issue and remove the input
             this.errors.push(
-                JSON.stringify(error.issues.slice(0, 1).map(i => {
+                error.issues.slice(0, 1).map(i => {
                     return {
                     ...i,
                         path: i.path?.map(p => {
@@ -68,13 +64,19 @@ export default class RequestLogger {
                             }
                         })
                     }
-                }), null, 4)            
-            );
-        } else {
-            this.errors.push(JSON.stringify({
+                }           
+            ));
+        } else if (error instanceof Error)  {
+            this.errors.push({
                 message: error.message,
                 stack: error.stack,
-            }, null, 4));
+            });
+        } else {
+            try {
+                this.errors.push(JSON.stringify(error));
+            } catch (e) {
+                this.errors.push(error);
+            }
         }
     }
 
@@ -105,8 +107,8 @@ export default class RequestLogger {
             response: {
                 statusCode: statusCode || 500,
                 contentLength: body ? body.length : 0,
-                body: body,
             },
+            errors: this.errors,
         };
     }
 
@@ -129,6 +131,7 @@ export default class RequestLogger {
                 query: eventRequest.querystring,
             },
             response: eventResponse,
+            errors: this.errors,
         };
     }
 
@@ -144,18 +147,15 @@ export default class RequestLogger {
         const parsedResponse: LogPackage["response"] = {
             statusCode: 500,
             contentLength: 0,
-            body: undefined,
         };
 
         if (typeof response === "object" && response !== null) {
             if (typeof (response as CloudFrontResultResponse).status === "string") {
                 parsedResponse.statusCode = parseInt((response as CloudFrontResultResponse).status);
                 parsedResponse.contentLength = (response as CloudFrontResultResponse).body?.length || 0;
-                parsedResponse.body = (response as CloudFrontResultResponse).body;
             } else if (typeof response.body === "object" && response.body !== null && typeof response.body.data === "string") {
                 parsedResponse.statusCode = 200; // Pass-through response code
                 parsedResponse.contentLength = response.body.data.length;
-                parsedResponse.body = response.body.data;
             }
         }
         

--- a/src/app/resources-controller-actions.ts
+++ b/src/app/resources-controller-actions.ts
@@ -3,8 +3,10 @@ import mime from "mime";
 import { InternalResources } from "../resources";
 import { getResource, listResources } from "../utils/data/repositories/ResourceRepository";
 import { generateSimpleHash } from "../utils/helpers";
+import RequestApp from "./RequestApp";
 
 export async function engageResourcesAction(
+    app: RequestApp,
     resourceURI: string,
     params: Record<string, string>
 ): Promise<{
@@ -25,7 +27,7 @@ export async function engageResourcesAction(
 
     const resource = getResource(resourceName);
     if (resource) {
-        const resourceResponse = await resource.retrieve(params);
+        const resourceResponse = await resource.retrieve(app, params);
 
         // If resource size is larger than 1MB, store it in S3 and redirect to it instead
         // This is a workaround to avoid CloudFront cache limit

--- a/src/codesets.test.ts
+++ b/src/codesets.test.ts
@@ -1,25 +1,60 @@
 import { test } from '@jest/globals';
-import { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda';
+import { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { offlineHandler } from './codesets';
+import { OccupationsResponseSchema } from './resources/internal/BusinessFinlandEscoOccupations';
 
 jest.mock('node:fetch');
 
-test('Basic router test', async () => {
-    // Mock event
-    const event = {
-        rawPath: '/resources/bazz',
+function mockEvent(path: string, method = "POST"): APIGatewayProxyEventV2 {
+    return {
+        rawPath: path,
         requestContext: {
             http: {
-                method: 'GET',
+                method: method,
             },
         },
         headers: {
             'x-amzn-trace-id': "Root=1-abba-1234",
         },
     } as unknown as APIGatewayProxyEventV2;
+}
 
-    const result = (await offlineHandler(event)) as unknown as APIGatewayProxyStructuredResultV2;
+describe('Basic router tests', () => {
+    test('Not found', async () => {
+        const notFound = await offlineHandler(mockEvent("/resources/bazz"));
+        expect(notFound.statusCode).toBe(404);
+        expect(notFound.body).toBeDefined();
+    });
 
-    expect(result.statusCode).toBe(404);
-    expect(result.body).toBeDefined();
+    test('List resources', async () => {
+        const listResources = await offlineHandler(mockEvent("/resources"));
+        expect(listResources.statusCode).toBe(200);
+        expect(listResources.body).toBeDefined();
+    });
+
+    test('Esco result', async () => {
+        const escoResult = await offlineHandler(mockEvent("/resources/BusinessFinlandEscoOccupations"));
+        expect(escoResult.statusCode).toBe(200);
+        expect(escoResult.body).toBeDefined();
+    });
+});
+
+describe('Data integrity tests', () => {
+    test('ESCO API data', async () => {
+        const escoResult = await offlineHandler(mockEvent("/resources/BusinessFinlandEscoOccupations"));
+        expect(escoResult.statusCode).toBe(200);
+        expect(escoResult.body).toBeDefined();
+
+        expect(() => {
+            OccupationsResponseSchema.parse(JSON.parse(escoResult.body as string));
+        }).not.toThrow();
+
+        expect(() => {
+            OccupationsResponseSchema.parse({ totalCount: 0, occupations: [] });
+        }).not.toThrow();
+
+        expect(() => {
+            OccupationsResponseSchema.parse({ totalCount: 0, occupations: [{ escoCode: 'foo' }] });
+        }).toThrow();
+    });
 });

--- a/src/codesets.ts
+++ b/src/codesets.ts
@@ -4,15 +4,15 @@ import {
     CloudFrontRequestEvent,
     CloudFrontRequestResult
 } from 'aws-lambda';
-import RequestLogger from './app/RequestLogger';
-import { engageResourcesAction } from './app/resources-controller';
+import RequestApp from './app/RequestApp';
+import { engageResourcesAction } from './app/resources-controller-actions';
 import { InternalResources } from './resources/index';
-import { resolveErrorPackage, resolveUri } from './utils/api';
+import { resolveErrorResponse, resolveUri } from './utils/api';
 import { decodeBase64, parseRequestInputParams } from './utils/helpers';
 import S3BucketStorage from './utils/lib/S3BucketStorage';
-import { Environment, getInternalResourceInfo } from './utils/runtime';
+import { getInternalResourceInfo } from './utils/runtime';
 
-const loggerConfiguration = {
+const loggerSettings = {
     disable: {
         sourceIp: true,
     },
@@ -25,13 +25,19 @@ const loggerConfiguration = {
  * @returns
  */
 export async function handler(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
-    const requestLogger = new RequestLogger(event, loggerConfiguration);
-    const response = await handleLiveRequest(event);
-    requestLogger.log(response);
+    const app = new RequestApp(event, {
+        loggerSettings: loggerSettings,
+        storage: new S3BucketStorage({
+            region: 'us-east-1', // Codesets bucket must be stored in us-east-1 for CloudFront to access it
+        })
+    });
+    
+    const response = await handleLiveRequest(app, event);
+    app.logger.log(response);
     return response;
 }
 
-async function handleLiveRequest(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
+async function handleLiveRequest(app: RequestApp, event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
     try {
         const request = event.Records[0].cf.request;
         let uri = resolveUri(request.uri);
@@ -47,16 +53,15 @@ async function handleLiveRequest(event: CloudFrontRequestEvent): Promise<CloudFr
             }
         }
 
-
         if (uri.startsWith('/resources')) {
-            const routerResponse = await engageResourcesAction(uri, params);
+            const routerResponse = await engageResourcesAction(app, uri, params);
             if (routerResponse.response) {
                 return routerResponse.response;
             }
 
             if (routerResponse.cacheable) {
                 const bucketName = getInternalResourceInfo().name;
-                await S3BucketStorage.store(
+                await app.storage.store(
                     bucketName,
                     routerResponse.cacheable.filepath,
                     routerResponse.cacheable.data,
@@ -85,7 +90,8 @@ async function handleLiveRequest(event: CloudFrontRequestEvent): Promise<CloudFr
         request.uri = uri; // Pass through to origin
         return request;
     } catch (error: any) {
-        const errorPackage = resolveErrorPackage(error);
+        app.logger.catchError(error);
+        const errorPackage = resolveErrorResponse(error);
         return {
             status: errorPackage.statusCode.toString(),
             statusDescription: errorPackage.description,
@@ -101,10 +107,16 @@ async function handleLiveRequest(event: CloudFrontRequestEvent): Promise<CloudFr
  * @returns
  */
 export async function offlineHandler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-    Environment.isLocal = true;
-    const requestLogger = new RequestLogger(event, loggerConfiguration);
-    const response = await handleLocalEvent(event);
-    requestLogger.log(response);
+    
+    const app = new RequestApp(event, {
+        loggerSettings: loggerSettings,
+        runtimeFlags: {
+            isLocal: true,
+        }
+    });
+    
+    const response = await handleLocalEvent(app, event);
+    app.logger.log(response);
     return response;
 }
 
@@ -114,7 +126,7 @@ export async function offlineHandler(event: APIGatewayProxyEventV2): Promise<API
  * @param event
  * @returns
  */
-async function handleLocalEvent(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+async function handleLocalEvent(app: RequestApp,event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
     try {
         const handle = async (event: APIGatewayProxyEventV2) => {
             let uri = resolveUri(event.rawPath);
@@ -131,7 +143,7 @@ async function handleLocalEvent(event: APIGatewayProxyEventV2): Promise<APIGatew
             }
 
             if (uri.startsWith('/resources')) {
-                const routerResponse: any = await engageResourcesAction(uri, params);
+                const routerResponse: any = await engageResourcesAction(app, uri, params);
                 if (routerResponse.response) {
                     return {
                         statusCode: parseInt(routerResponse.response.status),
@@ -178,6 +190,7 @@ async function handleLocalEvent(event: APIGatewayProxyEventV2): Promise<APIGatew
 
         return await Promise.race([handle(event), internalTimeoutEnforcer() as any]); // Return the first to resolve
     } catch (error: any) {
-        return resolveErrorPackage(error);
+        app.logger.catchError(error);
+        return resolveErrorResponse(error);
     }
 }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -7,6 +7,11 @@ function isFunctionalInternalResourceFile(resource: string): boolean {
     return resource.endsWith('.js') || resource.endsWith('.ts');
 }
 
+function cleanupResourceName(resourceName: string): string {
+    return resourceName.replace('/', '').replace(/\.js$/, '').replace(/\.ts$/, '');
+}
+
+
 const importDir = require('directory-import');
 const externalResourcesImport = importDir({ directoryPath: './external' });
 const internalResourcesImport = importDir({
@@ -15,7 +20,7 @@ const internalResourcesImport = importDir({
 const libraryResourcesImport = importDir({ directoryPath: './library' });
 
 const externalResources = Object.keys(externalResourcesImport).reduce((acc, key) => {
-    const resourceKey: string = key.replace('/', '').replace(/\.js$/, '');
+    const resourceKey = cleanupResourceName(key);
     const resource = externalResourcesImport[key].default;
 
     return {
@@ -29,7 +34,7 @@ const functionalInternalResources = Object.keys(internalResourcesImport).reduce(
         return acc;
     }
 
-    const resourceKey: string = key.replace('/', '').replace(/\.js$/, '');
+    const resourceKey = cleanupResourceName(key);
     const resource = internalResourcesImport[key].default;
 
     return {
@@ -39,7 +44,7 @@ const functionalInternalResources = Object.keys(internalResourcesImport).reduce(
 }, {});
 
 const libraryResources = Object.keys(libraryResourcesImport).reduce((acc, key) => {
-    const resourceKey: string = key.replace('/', '').replace(/\.js$/, '');
+    const resourceKey = cleanupResourceName(key);
     const resource = libraryResourcesImport[key].default;
 
     if (resource instanceof LibraryResource) {

--- a/src/resources/internal/BusinessFinlandEscoOccupations.ts
+++ b/src/resources/internal/BusinessFinlandEscoOccupations.ts
@@ -11,7 +11,7 @@ const OccupationSchema = object({
     escoDescription: string(),
     escoIdentifier: string(),
 });
-const OccupationsResponseSchema = object({
+export const OccupationsResponseSchema = object({
     totalCount: number(),
     occupations: array(OccupationSchema),
 });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,4 @@
 import { ValiError } from "valibot";
-import { ValidationError } from './exceptions';
 
 export const UriRedirects: Record<string, string> = {
     '/productizer/draft/Employment/EscoOccupations': '/resources/BusinessFinlandEscoOccupations',
@@ -9,29 +8,14 @@ export function resolveUri(uri: string): string {
     return UriRedirects[uri] || uri;
 }
 
-export function resolveErrorPackage(error: Error): { statusCode: number; body: string; description: string } {
-    if (error instanceof ValidationError || error instanceof ValiError) {
-        if (error instanceof ValiError) {
-            // Cleanup the vali error to make it more accessible: only show the first issue and remove the input
-            console.debug('Validation errors: ', JSON.stringify(error.issues.slice(0, 1).map(i => {
-                return {
-                   ...i,
-                    path: i.path?.map(p => {
-                        return {
-                            ...p,
-                            input: undefined 
-                        }
-                    })
-                }
-            }), null, 4));
-        }
+export function resolveErrorResponse(error: Error): { statusCode: number; body: string; description: string } {
+    if (error instanceof ValiError) {
         return {
             statusCode: 400,
             description: 'Bad Request',
             body: error.message || 'Bad Request',
         };
     }
-
     return {
         statusCode: 500,
         description: 'Internal Server Error',

--- a/src/utils/data/models/ExternalResource.ts
+++ b/src/utils/data/models/ExternalResource.ts
@@ -1,4 +1,4 @@
-import { Environment } from '../../runtime';
+import { RuntimeFlags } from '../../runtime';
 import BaseResource from './shared/BaseResource';
 
 const inMemoryCache: Record<
@@ -16,14 +16,14 @@ export default class ExternalResource extends BaseResource {
         data: string;
         mime: string;
     }> {
-        if (Environment.isLocal && typeof inMemoryCache[this.uri] !== 'undefined') {
+        if (RuntimeFlags.isLocal && typeof inMemoryCache[this.uri] !== 'undefined') {
             console.log(`Using in-memory cache for resource: ${this.name}`);
             return inMemoryCache[this.uri];
         }
 
         const dataPackage = await super._retrieveDataPackage(params);
 
-        if (Environment.isLocal) {
+        if (RuntimeFlags.isLocal) {
             console.log(`Caching resource in-memory: ${this.name}`);
             inMemoryCache[this.uri] = dataPackage;
         }

--- a/src/utils/data/models/shared/BaseResource.ts
+++ b/src/utils/data/models/shared/BaseResource.ts
@@ -98,7 +98,6 @@ export default class BaseResource<I = any, O = any> implements IResource {
         mime: string;
     }> {
         if (typeof this._dataGetter === 'function') {
-            console.log("FORTS, datagetter");
             return await this._dataGetter(params);
         }
 
@@ -151,7 +150,6 @@ export default class BaseResource<I = any, O = any> implements IResource {
         if (typeof this._parsers.rawInput === 'function') {
             rawData = this._parsers.rawInput(rawData) as any;
         } else if (mime.startsWith('application/json')) {
-            console.log("HOITS", typeof rawData, JSON.stringify(rawData));
             rawData = JSON.parse(rawData);
         }
         return rawData;

--- a/src/utils/exceptions.ts
+++ b/src/utils/exceptions.ts
@@ -1,1 +1,16 @@
-export class ValidationError extends Error {}
+import { ValiError } from "valibot";
+
+export class ValidationError extends ValiError {
+    constructor(message: string) {
+        super([
+            {
+                reason: "unknown",
+                validation: "",
+                origin: "value",
+                message: message,
+                input: {},
+            }
+        ]);
+        this.name = "ValidationError";
+    }
+}

--- a/src/utils/lib/LocalMemoryStorage.ts
+++ b/src/utils/lib/LocalMemoryStorage.ts
@@ -1,0 +1,19 @@
+import mime from 'mime';
+import { IStorage } from "./IStorage";
+
+export default class LocalMemoryStorage implements IStorage {
+    private storage: Map<string, string> = new Map<string, string>();
+
+    async store(bucketName: string, key: string, data: string): Promise<void>
+    {
+        this.storage.set(`${bucketName}/${key}`, data);
+        return Promise.resolve();
+    }
+
+    async retrieve(bucketName: string, key: string): Promise<{ data: string; mime: string }>
+    {
+        const data = this.storage.get(`${bucketName}/${key}`);
+        if (data === undefined) throw new Error(`Key ${key} not found in bucket ${bucketName}`);
+        return Promise.resolve({ data, mime: mime.getType(key) || 'application/json' });
+    }
+}

--- a/src/utils/lib/S3BucketStorage.ts
+++ b/src/utils/lib/S3BucketStorage.ts
@@ -1,14 +1,19 @@
-import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand, S3Client, } from "@aws-sdk/client-s3";
 import { Readable } from "stream";
 import { leftTrimSlash } from '../helpers';
 import { IStorage } from './IStorage';
 
-class S3BucketStorage implements IStorage {
+export default class S3BucketStorage implements IStorage {
+    private readonly s3Client: S3Client;
+    public constructor({ region }: { region?: string } = {}) {
+        this.s3Client = new S3Client(
+            { region: region || process.env.AWS_REGION }
+        );
+    }
+
     public async store(bucketName: string, key: string, data: string, mime: string) {
         try {
-            const s3Client = new S3Client({
-                region: "us-east-1",
-            });
+            
             const params = {
                 Bucket: bucketName,
                 Key: leftTrimSlash(key),
@@ -16,7 +21,7 @@ class S3BucketStorage implements IStorage {
                 ContentType: mime,
             };
 
-            await s3Client.send(new PutObjectCommand(params));
+            await this.s3Client.send(new PutObjectCommand(params));
 
         } catch (error: any) {
             console.error(error?.message, error?.stack);
@@ -26,15 +31,13 @@ class S3BucketStorage implements IStorage {
 
     public async retrieve(bucketName: string, key: string): Promise<{ data: string; mime: string }> {
         try {
-            const s3Client = new S3Client({
-                region: "us-east-1",
-            });
+           
             const params = {
                 Bucket: bucketName,
                 Key: leftTrimSlash(key),
             };
 
-            const data  = await s3Client.send(new GetObjectCommand(params));
+            const data  = await this.s3Client.send(new GetObjectCommand(params));
 
             if (!data.Body) throw new Error('No data found in S3');
 
@@ -63,5 +66,3 @@ class S3BucketStorage implements IStorage {
         });
     }
 }
-
-export default new S3BucketStorage();

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -4,7 +4,7 @@ export function getInternalResourceInfo(): { name: string } {
     return bucketInfo;
 }
 
-// Lambda@edge does not have access to environment variables, so we mock them here to separate local and live environments
-export const Environment = {
+// Static mutable runtime flags reference
+export const RuntimeFlags = {
     isLocal: false,
 };

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -4,7 +4,7 @@ export function getInternalResourceInfo(): { name: string } {
     return bucketInfo;
 }
 
-// Static mutable runtime flags reference
+// Lambda@edge does not have access to environment variables, so we mock them here to separate local and live environments
 export const RuntimeFlags = {
     isLocal: false,
 };


### PR DESCRIPTION
- runtime settings as dependency injections
  - fixes the [aws-sdk v3 hotfix](https://github.com/Virtual-Finland-Development/codesets/pull/38) a better way by injecting the setup from the current app handler
- pass error debug logs to the current request app
  - one log event for one request