### PR TITLE
Ensure cloudwatch log groups of lambda functions on a fresh deployment

### DIFF
--- a/infra/apps/codesets/index.ts
+++ b/infra/apps/codesets/index.ts
@@ -16,7 +16,7 @@ const originAccessIdentity = createOriginAccessIdentity(setup);
 const s3bucketSetup = createS3Bucket(setup);
 const edgeLambdaPackage = createLambdaAtEdgeFunction(setup, s3bucketSetup);
 createS3BucketPermissions(setup, s3bucketSetup.bucket, originAccessIdentity, edgeLambdaPackage.lambdaAtEdgeRole);
-const cacheUpdaterFunction = createCacheUpdaterLambdaFunction(setup, s3bucketSetup.name);
+const cacheUpdaterPackage = createCacheUpdaterLambdaFunction(setup, s3bucketSetup.name);
 
 const standardLogsBucket = createStandardLogsBucket(setup);
 
@@ -29,7 +29,7 @@ const cloudFrontDistribution = createCloudFrontDistribution(
 );
 uploadAssetsToBucket(s3bucketSetup.bucket);
 
-invokeTheCacheUpdatingFunction(setup, cacheUpdaterFunction); // Regenerate external resources cache
+invokeTheCacheUpdatingFunction(setup, cacheUpdaterPackage.lambdaFunction); // Regenerate external resources cache
 createEdgeCacheInvalidation(setup, cloudFrontDistribution); // Invalidate the edge-cache of cloudfront
 
 // Outputs
@@ -41,4 +41,4 @@ export const standardLogsBucketDetails = {
     arn: standardLogsBucket.arn,
     id: standardLogsBucket.id
 }
-export const cacheUpdaterFunctionArn = cacheUpdaterFunction.arn;
+export const cacheUpdaterFunctionArn = cacheUpdaterPackage.lambdaFunction.arn;

--- a/infra/apps/codesets/resources/CacheUpdaterLambdaFunction.ts
+++ b/infra/apps/codesets/resources/CacheUpdaterLambdaFunction.ts
@@ -1,11 +1,9 @@
-
 import * as aws from '@pulumi/aws';
 import { local } from '@pulumi/command';
 import * as pulumi from '@pulumi/pulumi';
 import { ISetup } from '../../../utils/Setup';
 
 export function createCacheUpdaterLambdaFunction(setup: ISetup, bucketName: string) {
-
     const execRoleConfig = setup.getResourceConfig('CacheUpdaterLambdaFunctionExecRole');
     const functionExecRole = new aws.iam.Role(execRoleConfig.name, {
         assumeRolePolicy: JSON.stringify({
@@ -24,47 +22,62 @@ export function createCacheUpdaterLambdaFunction(setup: ISetup, bucketName: stri
     });
 
     // Attach S3 read-write policy to exec role
-    new aws.iam.RolePolicy(
-        setup.getResourceName('CacheUpdaterLambdaFunctionExecRoleS3RwPolicy'),
-        {
-            role: functionExecRole,
-            policy: JSON.stringify({
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Action: ['s3:GetObject', 's3:PutObject'],
-                        Resource: `arn:aws:s3:::${bucketName}/*`,
-                        Effect: 'Allow',
-                    },
-                ],
-            }),
-        }
-    );
-    
+    new aws.iam.RolePolicy(setup.getResourceName('CacheUpdaterLambdaFunctionExecRoleS3RwPolicy'), {
+        role: functionExecRole,
+        policy: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: ['s3:GetObject', 's3:PutObject'],
+                    Resource: `arn:aws:s3:::${bucketName}/*`,
+                    Effect: 'Allow',
+                },
+            ],
+        }),
+    });
+
     // Attach basic lambda execution policy
-    new aws.iam.RolePolicyAttachment(
-        setup.getResourceName('CacheUpdaterLambdaFunctionExecRolePolicyAttachment'),
-        {
-            role: functionExecRole,
-            policyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
-        }
-    );
+    new aws.iam.RolePolicyAttachment(setup.getResourceName('CacheUpdaterLambdaFunctionExecRolePolicyAttachment'), {
+        role: functionExecRole,
+        policyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+    });
 
     const functionConfig = setup.getResourceConfig('CacheUpdaterLambdaFunction');
-    const lambdaFunction = new aws.lambda.Function(
-        functionConfig.name,
-        {
-            role: functionExecRole.arn,
-            runtime: 'nodejs18.x',
-            handler: 'codesets-cache-updater.handler',
-            timeout: 900, // 15 minutes
-            memorySize: 1024,
-            code: new pulumi.asset.FileArchive('./dist/codesets'),
-            tags: functionConfig.tags,
-        }
-    );
+    const lambdaFunction = new aws.lambda.Function(functionConfig.name, {
+        role: functionExecRole.arn,
+        runtime: 'nodejs18.x',
+        handler: 'codesets-cache-updater.handler',
+        timeout: 900, // 15 minutes
+        memorySize: 1024,
+        code: new pulumi.asset.FileArchive('./dist/codesets'),
+        tags: functionConfig.tags,
+    });
 
-    return lambdaFunction;
+    const initialInvokeCommand = invokeInitialExecution(setup, lambdaFunction);
+
+    return {
+        lambdaFunction,
+        initialInvokeCommand,
+    };
+}
+
+/**
+ * Invokes the function once to ensure the creation of the log group
+ *
+ * @param setup
+ * @param lambdaFunction
+ */
+function invokeInitialExecution(setup: ISetup, lambdaFunction: aws.lambda.Function) {
+    const invokeConfig = setup.getResourceConfig('CacheUpdaterInitialExecution');
+    const awsConfig = new pulumi.Config('aws');
+    const region = awsConfig.require('region');
+    return new local.Command(
+        invokeConfig.name,
+        {
+            create: pulumi.interpolate`aws lambda invoke --payload '{"action": "ping"}' --cli-binary-format raw-in-base64-out --function-name ${lambdaFunction.name} --region ${region} /dev/null`,
+        },
+        { dependsOn: [lambdaFunction] }
+    );
 }
 
 export function invokeTheCacheUpdatingFunction(setup: ISetup, lambdaFunction: aws.lambda.Function) {
@@ -72,11 +85,8 @@ export function invokeTheCacheUpdatingFunction(setup: ISetup, lambdaFunction: aw
     const triggerToken = new Date().getTime().toString(); // Trigger always
     const awsConfig = new pulumi.Config('aws');
     const region = awsConfig.require('region');
-    new local.Command(
-        invokeConfig.name,
-        {
-            create: pulumi.interpolate`aws lambda invoke --function-name ${lambdaFunction.name} --region ${region} /dev/null`,
-            triggers: [triggerToken],
-        },
-    );
+    new local.Command(invokeConfig.name, {
+        create: pulumi.interpolate`aws lambda invoke --function-name ${lambdaFunction.name} --region ${region} /dev/null`,
+        triggers: [triggerToken],
+    });
 }

--- a/infra/apps/codesets/resources/LambdaAtEdge.ts
+++ b/infra/apps/codesets/resources/LambdaAtEdge.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws';
+import { local } from '@pulumi/command';
 import * as pulumi from '@pulumi/pulumi';
 import * as fs from 'fs';
 import { ISetup } from '../../../utils/Setup';
@@ -45,7 +46,6 @@ export default function createLambdaAtEdgeFunction(
             name: s3BucketSetup.name,
         })
     );
-    console.log('Wrote bucket info to dist folder');
 
     const lambdaAtEdgeFunctionConfig = setup.getResourceConfig('LambdaAtEdge');
     const lambdaAtEdgeFunction = new aws.lambda.Function(lambdaAtEdgeFunctionConfig.name, {
@@ -59,8 +59,30 @@ export default function createLambdaAtEdgeFunction(
         publish: true,
     });
 
+    const initialInvokeCommand = invokeInitialExecution(setup, lambdaAtEdgeFunction);
+
     return {
         lambdaAtEdgeFunction,
         lambdaAtEdgeRole,
+        initialInvokeCommand,
     };
+}
+
+/**
+ * Invokes the function once to ensure the creation of the log group
+ *
+ * @param setup
+ * @param lambdaFunction
+ */
+function invokeInitialExecution(setup: ISetup, lambdaFunction: aws.lambda.Function) {
+    const invokeConfig = setup.getResourceConfig('LambdaAtEdgeInitialInvoke');
+    const awsConfig = new pulumi.Config('aws');
+    const region = awsConfig.require('region');
+    return new local.Command(
+        invokeConfig.name,
+        {
+            create: pulumi.interpolate`aws lambda invoke --payload '{"action": "ping"}' --cli-binary-format raw-in-base64-out --function-name ${lambdaFunction.name} --region ${region} /dev/null`,
+        },
+        { dependsOn: [lambdaFunction] }
+    );
 }

--- a/infra/apps/escoApi/package-lock.json
+++ b/infra/apps/escoApi/package-lock.json
@@ -7,6 +7,7 @@
       "name": "escoapi-infra",
       "dependencies": {
         "@pulumi/aws": "^5.41.0",
+        "@pulumi/command": "^0.7.2",
         "@pulumi/pulumi": "^3.69.0"
       },
       "devDependencies": {
@@ -317,6 +318,15 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@pulumi/command": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.7.2.tgz",
+      "integrity": "sha512-R/eAIXIywSkn2cHIaNqs0EXcXduNeDuS+wom6oadB5KEP+6elgJbo4WMDP+OuDYGkkxEWIKjk0bPPO7570aXFQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
       }
     },
     "node_modules/@pulumi/pulumi": {

--- a/infra/apps/escoApi/package.json
+++ b/infra/apps/escoApi/package.json
@@ -3,7 +3,8 @@
   "main": "index.ts",
   "dependencies": {
     "@pulumi/aws": "^5.41.0",
-    "@pulumi/pulumi": "^3.69.0"
+    "@pulumi/pulumi": "^3.69.0",
+    "@pulumi/command": "^0.7.2"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/src/codesets-cache-updater.ts
+++ b/src/codesets-cache-updater.ts
@@ -1,12 +1,16 @@
 import RequestLogger from './app/RequestLogger';
 import { getResources } from './utils/data/repositories/ResourceRepository';
-import { RuntimeFlags } from './utils/runtime';
+import { RuntimeFlags, isPingEvent } from './utils/runtime';
 import ExternalResourceCache from './utils/services/ExternalResourceCache';
 import S3BucketStorage from './utils/services/S3BucketStorage';
 
-export async function handler() {
+export async function handler(event: any) {
+    if (isPingEvent(event)) {
+        return;
+    }
+
     RuntimeFlags.isSystemTask = true; // Flag the resources system to skip existing cache usage
-    
+
     const externalResources = getResources('external');
     const appStorage = new S3BucketStorage({
         region: 'us-east-1', // Codesets bucket must be stored in us-east-1 for CloudFront to access it
@@ -15,7 +19,7 @@ export async function handler() {
 
     for (const resourceName in externalResources) {
         const resource = externalResources[resourceName];
-        console.log("Updating resource..", resourceName);
+        console.log('Updating resource..', resourceName);
 
         try {
             // Fetch data response string
@@ -23,10 +27,9 @@ export async function handler() {
 
             // Validate input/output by parsing
             await resource.parseRawData(dataPackage.data, dataPackage.mime);
-            
+
             // Store data in cache
             await externalResourceCache.store(resource.name, dataPackage);
-            
         } catch (error) {
             console.error(resourceName, RequestLogger.formatError(error));
             // @TODO: alerts to admin

--- a/src/codesets-cache-updater.ts
+++ b/src/codesets-cache-updater.ts
@@ -1,14 +1,10 @@
 import RequestLogger from './app/RequestLogger';
 import { getResources } from './utils/data/repositories/ResourceRepository';
-import { RuntimeFlags, isPingEvent } from './utils/runtime';
+import { RuntimeFlags, pingEventMiddleware } from './utils/runtime';
 import ExternalResourceCache from './utils/services/ExternalResourceCache';
 import S3BucketStorage from './utils/services/S3BucketStorage';
 
-export async function handler(event: any) {
-    if (isPingEvent(event)) {
-        return;
-    }
-
+export const handler = pingEventMiddleware(async () => {
     RuntimeFlags.isSystemTask = true; // Flag the resources system to skip existing cache usage
 
     const externalResources = getResources('external');
@@ -35,4 +31,4 @@ export async function handler(event: any) {
             // @TODO: alerts to admin
         }
     }
-}
+});

--- a/src/codesets.ts
+++ b/src/codesets.ts
@@ -2,14 +2,14 @@ import {
     APIGatewayProxyEventV2,
     APIGatewayProxyStructuredResultV2,
     CloudFrontRequestEvent,
-    CloudFrontRequestResult
+    CloudFrontRequestResult,
 } from 'aws-lambda';
 import RequestApp from './app/RequestApp';
 import { engageResourcesAction } from './app/resources-controller-actions';
 import { InternalResources } from './resources/index';
 import { resolveErrorResponse, resolveUri } from './utils/api';
 import { decodeBase64, parseRequestInputParams } from './utils/helpers';
-import { getStorageBucketInfo } from './utils/runtime';
+import { getStorageBucketInfo, isPingEvent } from './utils/runtime';
 import S3BucketStorage from './utils/services/S3BucketStorage';
 
 const loggerSettings = {
@@ -25,13 +25,17 @@ const loggerSettings = {
  * @returns
  */
 export async function handler(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
+    if (isPingEvent(event)) {
+        return;
+    }
+
     const app = new RequestApp(event, {
         loggerSettings: loggerSettings,
         storage: new S3BucketStorage({
             region: 'us-east-1', // Codesets bucket must be stored in us-east-1 for CloudFront to access it
-        })
+        }),
     });
-    
+
     const response = await handleLiveRequest(app, event);
     app.logger.log(response);
     return response;
@@ -107,14 +111,13 @@ async function handleLiveRequest(app: RequestApp, event: CloudFrontRequestEvent)
  * @returns
  */
 export async function offlineHandler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-    
     const app = new RequestApp(event, {
         loggerSettings: loggerSettings,
         runtimeFlags: {
             isLocal: true,
-        }
+        },
     });
-    
+
     const response = await handleLocalEvent(app, event);
     app.logger.log(response);
     return response;
@@ -126,7 +129,10 @@ export async function offlineHandler(event: APIGatewayProxyEventV2): Promise<API
  * @param event
  * @returns
  */
-async function handleLocalEvent(app: RequestApp,event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+async function handleLocalEvent(
+    app: RequestApp,
+    event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyStructuredResultV2> {
     try {
         const handle = async (event: APIGatewayProxyEventV2) => {
             let uri = resolveUri(event.rawPath);

--- a/src/codesets.ts
+++ b/src/codesets.ts
@@ -9,7 +9,7 @@ import { engageResourcesAction } from './app/resources-controller-actions';
 import { InternalResources } from './resources/index';
 import { resolveErrorResponse, resolveUri } from './utils/api';
 import { decodeBase64, parseRequestInputParams } from './utils/helpers';
-import { getStorageBucketInfo, isPingEvent } from './utils/runtime';
+import { getStorageBucketInfo, pingEventMiddleware } from './utils/runtime';
 import S3BucketStorage from './utils/services/S3BucketStorage';
 
 const loggerSettings = {
@@ -24,11 +24,7 @@ const loggerSettings = {
  * @param event
  * @returns
  */
-export async function handler(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
-    if (isPingEvent(event)) {
-        return;
-    }
-
+export const handler = pingEventMiddleware(async (event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> => {
     const app = new RequestApp(event, {
         loggerSettings: loggerSettings,
         storage: new S3BucketStorage({
@@ -39,7 +35,7 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
     const response = await handleLiveRequest(app, event);
     app.logger.log(response);
     return response;
-}
+});
 
 async function handleLiveRequest(app: RequestApp, event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
     try {

--- a/src/escoApi.ts
+++ b/src/escoApi.ts
@@ -3,6 +3,7 @@ import RequestApp from './app/RequestApp';
 import { UriRedirects, resolveErrorResponse } from './utils/api';
 import { transformOccupations } from './utils/data/transformers';
 import { NotFoundError, ValidationError } from './utils/exceptions';
+import { isPingEvent } from './utils/runtime';
 
 const CODESETS_API_ENDPOINT = process.env.CODESETS_API_ENDPOINT;
 
@@ -12,7 +13,11 @@ const internalMemory: any = {
 };
 
 // AWS Lambda function handler for the ESCO API
-export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2 | undefined> {
+    if (isPingEvent(event)) {
+        return;
+    }
+
     const app = new RequestApp(event);
     const response = await handleEvent(app, event);
     app.logger.log(response);

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -9,3 +9,24 @@ export const RuntimeFlags = {
     isLocal: false,
     isSystemTask: false,
 };
+
+/**
+ *
+ * @param event
+ * @returns - true if the event is a ping event, false otherwise
+ */
+export function isPingEvent(event: any): boolean {
+    if (event.body) {
+        try {
+            const body = JSON.parse(event.body);
+            if (body.action === 'ping') {
+                console.log('pong');
+                return true;
+            }
+        } catch (e) {
+            console.error('Invalid event body', event.body);
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -10,23 +10,12 @@ export const RuntimeFlags = {
     isSystemTask: false,
 };
 
-/**
- *
- * @param event
- * @returns - true if the event is a ping event, false otherwise
- */
-export function isPingEvent(event: any): boolean {
-    if (event.body) {
-        try {
-            const body = JSON.parse(event.body);
-            if (body.action === 'ping') {
-                console.log('pong');
-                return true;
-            }
-        } catch (e) {
-            console.error('Invalid event body', event.body);
-            return true;
+export function pingEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
+    return async function (event: any, context?: any) {
+        if (event.action === 'ping') {
+            console.log('pong');
+            return;
         }
-    }
-    return false;
+        return next(event, context);
+    };
 }


### PR DESCRIPTION
The lambda function log groups are created on runtime, not on install-time, so creating log group subscriptions with the same pulumi deployment is tricky on a fresh deployment where no resources yet exist. 

This PR fixes the circular dependency situation by creating an initial function invocation that logs once thus creating the log group for the function. The initial exec is a simple ping-pong style action.