### PR TITLE
Cloudwatch subscriptions for all the regions

### DIFF
--- a/infra/apps/codesets/index.ts
+++ b/infra/apps/codesets/index.ts
@@ -4,18 +4,18 @@ import {
     createCacheUpdaterLambdaFunction,
     invokeTheCacheUpdatingFunction,
 } from './resources/CacheUpdaterLambdaFunction';
+import { createChatbotSlackConfig } from './resources/Chatbot';
 import {
     createCloudFrontDistribution,
     createEdgeCacheInvalidation,
     createOriginAccessIdentity,
 } from './resources/CloudFront';
+import { createCloudWatchLogSubFilter } from './resources/CloudWatch';
+import { createErrorSubLambdaFunction } from './resources/ErrorSubLambdaFunction';
 import createLambdaAtEdgeFunction from './resources/LambdaAtEdge';
 import createS3Bucket, { createS3BucketPermissions, uploadAssetsToBucket } from './resources/S3Bucket';
-import { createStandardLogsBucket } from './resources/standardLogsBucket';
 import { createSnsTopicAndSubscriptions } from './resources/SNS';
-import { createErrorSubLambdaFunction, grantLambdaPermissionForCloudWatch } from './resources/ErrorSubLambdaFunction';
-import { createCloudWatchLogSubFilter } from './resources/CloudWatch';
-import { createChatbotSlackConfig } from './resources/Chatbot';
+import { createStandardLogsBucket } from './resources/standardLogsBucket';
 
 const setup = getSetup();
 const originAccessIdentity = createOriginAccessIdentity(setup);
@@ -41,12 +41,7 @@ createEdgeCacheInvalidation(setup, cloudFrontDistribution); // Invalidate the ed
 
 const { snSTopicForEmail, snsTopicForChatbot } = createSnsTopicAndSubscriptions(setup); // Create SNS topic and subscriptions
 const errorSubLambdaFunction = createErrorSubLambdaFunction(setup, snSTopicForEmail, snsTopicForChatbot); // Lambda function that will pass codesets errors to SNS
-const lambdaPermission = grantLambdaPermissionForCloudWatch(
-    setup,
-    edgeLambdaPackage.lambdaAtEdgeFunction,
-    errorSubLambdaFunction
-); // Grant Lambda permission for CloudWatch
-createCloudWatchLogSubFilter(setup, edgeLambdaPackage.lambdaAtEdgeFunction, errorSubLambdaFunction, lambdaPermission); // Create CloudWatch log subscription filter for errorSubLambdaFunction
+createCloudWatchLogSubFilter(setup, edgeLambdaPackage.lambdaAtEdgeFunction, errorSubLambdaFunction); // Create CloudWatch log subscription filter for errorSubLambdaFunction
 createChatbotSlackConfig(setup, snsTopicForChatbot); // Create AWS Chatbot Slack configuration for alerting
 
 // Outputs

--- a/infra/apps/codesets/index.ts
+++ b/infra/apps/codesets/index.ts
@@ -54,4 +54,4 @@ export const standardLogsBucketDetails = {
     id: standardLogsBucket.id,
 };
 export const cacheUpdaterFunctionArn = cacheUpdaterPackage.lambdaFunction.arn;
-export const errorSubLambdaFunctionId = pulumi.interpolate`${errorSubLambdaFunction.name}:${errorSubLambdaFunction.version}`;
+export const errorSubLambdaFunctionArn = errorSubLambdaFunction.arn;

--- a/infra/apps/codesets/resources/CacheUpdaterLambdaFunction.ts
+++ b/infra/apps/codesets/resources/CacheUpdaterLambdaFunction.ts
@@ -53,31 +53,9 @@ export function createCacheUpdaterLambdaFunction(setup: ISetup, bucketName: stri
         tags: functionConfig.tags,
     });
 
-    const initialInvokeCommand = invokeInitialExecution(setup, lambdaFunction);
-
     return {
         lambdaFunction,
-        initialInvokeCommand,
     };
-}
-
-/**
- * Invokes the function once to ensure the creation of the log group
- *
- * @param setup
- * @param lambdaFunction
- */
-function invokeInitialExecution(setup: ISetup, lambdaFunction: aws.lambda.Function) {
-    const invokeConfig = setup.getResourceConfig('CacheUpdaterInitialExecution');
-    const awsConfig = new pulumi.Config('aws');
-    const region = awsConfig.require('region');
-    return new local.Command(
-        invokeConfig.name,
-        {
-            create: pulumi.interpolate`aws lambda invoke --payload '{"action": "ping"}' --cli-binary-format raw-in-base64-out --function-name ${lambdaFunction.name} --region ${region} /dev/null`,
-        },
-        { dependsOn: [lambdaFunction] }
-    );
 }
 
 export function invokeTheCacheUpdatingFunction(setup: ISetup, lambdaFunction: aws.lambda.Function) {

--- a/infra/apps/codesets/resources/CloudFront.ts
+++ b/infra/apps/codesets/resources/CloudFront.ts
@@ -97,7 +97,7 @@ export function createCloudFrontDistribution(
             principal: 'edgelambda.amazonaws.com',
             sourceArn: cloudFrontDistribution.arn,
         },
-        { provider: setup.edgeRegion.provider }
+        { provider: setup.regions.edgeRegion.provider }
     );
 
     return cloudFrontDistribution;

--- a/infra/apps/codesets/resources/CloudWatch.ts
+++ b/infra/apps/codesets/resources/CloudWatch.ts
@@ -1,29 +1,48 @@
-import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
 import { ISetup } from '../../../utils/Setup';
 
 export async function createCloudWatchLogSubFilter(
     setup: ISetup,
     codesetsLambda: aws.lambda.Function,
-    errorSubLambda: aws.lambda.Function,
-    lambdaPermission: aws.lambda.Permission
+    errorSubLambda: aws.lambda.Function
 ) {
     const edgeLambdaLogGroupName = pulumi.interpolate`/aws/lambda/${codesetsLambda.name}`;
+    edgeLambdaLogGroupName.apply(async (logGroupName) => {
+        const providers = await setup.regions.getProviders();
+        for (const provider of providers) {
+            const logGroupConfig = setup.getResourceConfig(`edgeRegion-${provider.name}-logGroup`);
+            const logGroup = new aws.cloudwatch.LogGroup(logGroupConfig.name, {
+                name: logGroupName,
+                retentionInDays: 30,
+                tags: logGroupConfig.tags,
+            });
 
-    const logSubFilter = new aws.cloudwatch.LogSubscriptionFilter(
-        setup.getResourceName('CloudWatchLogSubFilter'),
-        {
-            logGroup: edgeLambdaLogGroupName,
-            filterPattern: 'ERROR',
-            destinationArn: errorSubLambda.arn,
-        },
-        {
-            dependsOn: [lambdaPermission],
-            provider: setup.edgeRegion.provider,
+            const lambdaPermission = new aws.lambda.Permission(
+                setup.getResourceName(`ErrorSubLambdaFunctionPermission-${provider.name}`),
+                {
+                    action: 'lambda:InvokeFunction',
+                    function: errorSubLambda.name,
+                    principal: 'logs.us-east-1.amazonaws.com',
+                    sourceArn: pulumi.interpolate`${logGroup.arn}:*`,
+                },
+                {
+                    provider: provider.provider,
+                }
+            );
+
+            new aws.cloudwatch.LogSubscriptionFilter(
+                setup.getResourceName(`CloudWatchLogSubFilter-${provider.name}`),
+                {
+                    logGroup: edgeLambdaLogGroupName,
+                    filterPattern: 'ERROR',
+                    destinationArn: errorSubLambda.arn,
+                },
+                {
+                    dependsOn: [logGroup, lambdaPermission],
+                    provider: provider.provider,
+                }
+            );
         }
-    );
-
-    return {
-        logSubFilter,
-    };
+    });
 }

--- a/infra/apps/codesets/resources/CloudWatch.ts
+++ b/infra/apps/codesets/resources/CloudWatch.ts
@@ -23,7 +23,7 @@ export async function createCloudWatchLogSubFilter(
                 {
                     action: 'lambda:InvokeFunction',
                     function: errorSubLambda.name,
-                    principal: 'logs.us-east-1.amazonaws.com',
+                    principal: 'logs.amazonaws.com',
                     sourceArn: pulumi.interpolate`${logGroup.arn}:*`,
                 },
                 {

--- a/infra/apps/codesets/resources/ErrorSubLambdaFunction.ts
+++ b/infra/apps/codesets/resources/ErrorSubLambdaFunction.ts
@@ -73,7 +73,7 @@ export function createErrorSubLambdaFunction(
             environment: {
                 variables: {
                     STAGE: setup.stage,
-                    LOG_GROUPS_REGION: pulumi.interpolate`${setup.regions.edgeRegion.provider.region}`,
+                    PRIMARY_AWS_REGION: pulumi.interpolate`${setup.regions.resourcesRegion.name}`,
                     SNS_TOPIC_EMAIL_ARN: snsTopicForEmail.arn,
                     SNS_TOPIC_CHATBOT_ARN: snsTopicForChatbot.arn,
                 },

--- a/infra/apps/codesets/resources/ErrorSubLambdaFunction.ts
+++ b/infra/apps/codesets/resources/ErrorSubLambdaFunction.ts
@@ -27,7 +27,7 @@ export function createErrorSubLambdaFunction(
             tags: execRoleConfig.tags,
         },
         {
-            provider: setup.edgeRegion.provider,
+            provider: setup.regions.edgeRegion.provider,
         }
     );
 
@@ -48,7 +48,7 @@ export function createErrorSubLambdaFunction(
             }),
         },
         {
-            provider: setup.edgeRegion.provider,
+            provider: setup.regions.edgeRegion.provider,
         }
     );
 
@@ -73,47 +73,16 @@ export function createErrorSubLambdaFunction(
             environment: {
                 variables: {
                     STAGE: setup.stage,
-                    LOG_GROUPS_REGION: pulumi.interpolate`${setup.edgeRegion.provider.region}`,
+                    LOG_GROUPS_REGION: pulumi.interpolate`${setup.regions.edgeRegion.provider.region}`,
                     SNS_TOPIC_EMAIL_ARN: snsTopicForEmail.arn,
                     SNS_TOPIC_CHATBOT_ARN: snsTopicForChatbot.arn,
                 },
             },
         },
         {
-            provider: setup.edgeRegion.provider,
+            provider: setup.regions.edgeRegion.provider,
         }
     );
 
     return lambdaFunction;
-}
-
-export function grantLambdaPermissionForCloudWatch(
-    setup: ISetup,
-    codesetsLambda: aws.lambda.Function,
-    errorSubLambda: aws.lambda.Function
-) {
-    /**
-     * FROM aws.cloudwatch.LogSubscriptionFilter.roleArn
-     * The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination.
-     * If you use Lambda as a destination, you should skip this argument and use aws.lambda.Permission resource for granting access from CloudWatch logs to the destination Lambda function.
-     */
-    const codesetsLambdaLogGroupName = pulumi.interpolate`/aws/lambda/${codesetsLambda.name}`;
-    const logGroupSourceArn = codesetsLambdaLogGroupName.apply((name) =>
-        aws.cloudwatch.getLogGroup({ name }, { provider: setup.edgeRegion.provider }).then((logGroup) => logGroup.arn)
-    );
-
-    const lambdaPermission = new aws.lambda.Permission(
-        setup.getResourceName('ErrorSubLambdaFunctionPermission'),
-        {
-            action: 'lambda:InvokeFunction',
-            function: errorSubLambda.name,
-            principal: 'logs.us-east-1.amazonaws.com',
-            sourceArn: pulumi.interpolate`${logGroupSourceArn}:*`,
-        },
-        {
-            provider: setup.edgeRegion.provider,
-        }
-    );
-
-    return lambdaPermission;
 }

--- a/infra/apps/codesets/resources/LambdaAtEdge.ts
+++ b/infra/apps/codesets/resources/LambdaAtEdge.ts
@@ -51,7 +51,7 @@ export default function createLambdaAtEdgeFunction(
         './dist/codesets/build/bucket-info.json',
         JSON.stringify({
             name: s3BucketSetup.name,
-            region: setup.regions.resourcesRegion.region,
+            region: setup.regions.resourcesRegion.name,
         })
     );
 

--- a/infra/utils/Setup.ts
+++ b/infra/utils/Setup.ts
@@ -33,18 +33,18 @@ const resourcesRegionProvider = new aws.Provider('resourses-region', {
     region: resourcesRegion as pulumi.Input<aws.Region> | undefined,
 });
 
-async function getProviders() {
+async function getAllRegions() {
     const edgeRegions = await aws.getRegions({});
-    const providers = [];
+    const regions = [];
     for (const region of edgeRegions.names) {
-        providers.push({
+        regions.push({
             name: region,
             provider: new aws.Provider(getResourceName(`region-${region}`), {
                 region: region as pulumi.Input<aws.Region> | undefined,
             }),
         });
     }
-    return providers;
+    return regions;
 }
 
 const setup = {
@@ -55,7 +55,7 @@ const setup = {
     getResourceName,
     isProductionLikeEnvironment,
     regions: {
-        getProviders: getProviders,
+        getAllRegions: getAllRegions,
         edgeRegion: {
             region: edgeRegion,
             provider: edgeRegionProvider,

--- a/infra/utils/Setup.ts
+++ b/infra/utils/Setup.ts
@@ -1,6 +1,28 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 
+const stage = pulumi.getStack();
+const projectName = pulumi.getProject();
+const organizationName = pulumi.getOrganization();
+
+function getResourceConfig(name: string) {
+    return {
+        name: getResourceName(name),
+        tags: {
+            'vfd:stack': stage,
+            'vfd:project': projectName,
+        },
+    };
+}
+
+function getResourceName(name: string) {
+    return `${projectName}-${name}-${stage}`;
+}
+
+function isProductionLikeEnvironment() {
+    return stage.endsWith('production') || stage.endsWith('staging');
+}
+
 const edgeRegion = new pulumi.Config('codesets').require('edgeRegion');
 const edgeRegionProvider = new aws.Provider('edge-region', {
     region: edgeRegion as pulumi.Input<aws.Region> | undefined,
@@ -11,32 +33,37 @@ const resourcesRegionProvider = new aws.Provider('resourses-region', {
     region: resourcesRegion as pulumi.Input<aws.Region> | undefined,
 });
 
+async function getProviders() {
+    const edgeRegions = await aws.getRegions({});
+    const providers = [];
+    for (const region of edgeRegions.names) {
+        providers.push({
+            name: region,
+            provider: new aws.Provider(getResourceName(`region-${region}`), {
+                region: region as pulumi.Input<aws.Region> | undefined,
+            }),
+        });
+    }
+    return providers;
+}
+
 const setup = {
-    stage: pulumi.getStack(),
-    projectName: pulumi.getProject(),
-    organizationName: pulumi.getOrganization(),
-    getResourceConfig(name: string) {
-        return {
-            name: this.getResourceName(name),
-            tags: {
-                'vfd:stack': this.stage,
-                'vfd:project': this.projectName,
-            },
-        };
-    },
-    getResourceName(name: string) {
-        return `${this.projectName}-${name}-${this.stage}`;
-    },
-    isProductionLikeEnvironment() {
-        return this.stage.endsWith('production') || this.stage.endsWith('staging');
-    },
-    edgeRegion: {
-        region: edgeRegion,
-        provider: edgeRegionProvider,
-    },
-    resourcesRegion: {
-        region: resourcesRegion,
-        provider: resourcesRegionProvider,
+    stage,
+    projectName,
+    organizationName,
+    getResourceConfig,
+    getResourceName,
+    isProductionLikeEnvironment,
+    regions: {
+        getProviders: getProviders,
+        edgeRegion: {
+            region: edgeRegion,
+            provider: edgeRegionProvider,
+        },
+        resourcesRegion: {
+            region: resourcesRegion,
+            provider: resourcesRegionProvider,
+        },
     },
 };
 

--- a/src/codesets-error-subscriber.ts
+++ b/src/codesets-error-subscriber.ts
@@ -48,11 +48,11 @@ function publishSnsMessage(topicArn: string, message: string) {
 function transformTextToMarkdown(text: string) {
     // Newlines of the form \\n are escaped to \n
     text = text.replace(/\\\n/g, '\n');
-    // Newlines of the form \n are escaped to \\n
+    // Newlines of the form \\n are escaped to \n
     text = text.replace(/\\n/g, '\n');
-    // Tabs of the form \t are escaped to \\t
+    // Tabs of the form \\t are escaped to \t
     text = text.replace(/\\t/g, '\t');
-    // Quotes of the form \" are escaped to \\"
+    // Quotes of the form \\" are escaped to \"
     text = text.replace(/\\"/g, '"');
     // The first and last quote are removed
     text = text.replace(/^"/, '').replace(/"$/, '');

--- a/src/codesets-error-subscriber.ts
+++ b/src/codesets-error-subscriber.ts
@@ -45,7 +45,21 @@ function publishSnsMessage(topicArn: string, message: string) {
     );
 }
 
-const snsClient = new SNSClient({ region: 'eu-north-1' });
+function transformTextToMarkdown(text: string) {
+    // Newlines of the form \\n are escaped to \n
+    text = text.replace(/\\\n/g, '\n');
+    // Newlines of the form \n are escaped to \\n
+    text = text.replace(/\\n/g, '\n');
+    // Tabs of the form \t are escaped to \\t
+    text = text.replace(/\\t/g, '\t');
+    // Quotes of the form \" are escaped to \\"
+    text = text.replace(/\\"/g, '"');
+    // The first and last quote are removed
+    text = text.replace(/^"/, '').replace(/"$/, '');
+    return text;
+}
+
+const snsClient = new SNSClient({ region: primaryRegion });
 const isHandlingTimeout = 1000 * 60; // 1 minute
 let isHandlingEvent = false;
 
@@ -91,7 +105,7 @@ export const handler = async (event: CloudWatchLogsEvent) => {
                 source: 'custom',
                 content: {
                     title: ':boom: Codesets Error! :boom:',
-                    description: messageString,
+                    description: transformTextToMarkdown(messageString),
                     nextSteps: [
                         // https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages
                         ...(logEventsUrl ? [`<${logEventsUrl}|View in AWS console>`] : []),


### PR DESCRIPTION
- hieman muuttelee Setup.ts -rakennetta mm. region-tietojen osalta
- luo kaikille aws-regioneille (mitä tilillä on päällä) edge-funkkarin log-groupin ja sille subscriptionin sekä invoke-permissionin error-lambda -funktioon
- jos deplataan olemassa olevaan liveen niin jo olemassa olevat logiryhmät tarvii käsin importata pulumiin esim: `pulumi import aws:cloudwatch/logGroup:LogGroup codesets-<logi-resurssille-nimi>-dev /aws/lambda/codesets-jotainjotain-dev-abba2` tai helpommin käydä konsolissa poistamassa
- tehty error-lambdaan parseri joka kaivelee kyseisen eventin payloadista eventin regionin -> cloudwatch-linkin muodostukseen
- vähän muoksittu chatbotin ulosantia että hieman luettavampi slack-viesti