### PR TITLE
Add health checking route

### DIFF
--- a/src/codesets-cache-updater.ts
+++ b/src/codesets-cache-updater.ts
@@ -2,9 +2,10 @@ import { ValiError } from 'valibot';
 import RequestLogger from './app/RequestLogger';
 import { getResources } from './utils/data/repositories/ResourceRepository';
 import { ResourceRetrievalError } from './utils/exceptions';
-import { RuntimeFlags, healthCheckEventMiddleware } from './utils/runtime';
+import { RuntimeFlags } from './utils/runtime';
 import ExternalResourceCache from './utils/services/ExternalResourceCache';
 import S3BucketStorage from './utils/services/S3BucketStorage';
+import { healthCheckEventMiddleware } from './utils/middlewares';
 
 export const handler = healthCheckEventMiddleware(async () => {
     RuntimeFlags.isSystemTask = true; // Flag the resources system to skip existing cache usage

--- a/src/codesets-cache-updater.ts
+++ b/src/codesets-cache-updater.ts
@@ -2,11 +2,11 @@ import { ValiError } from 'valibot';
 import RequestLogger from './app/RequestLogger';
 import { getResources } from './utils/data/repositories/ResourceRepository';
 import { ResourceRetrievalError } from './utils/exceptions';
-import { RuntimeFlags, pingEventMiddleware } from './utils/runtime';
+import { RuntimeFlags, healthCheckEventMiddleware } from './utils/runtime';
 import ExternalResourceCache from './utils/services/ExternalResourceCache';
 import S3BucketStorage from './utils/services/S3BucketStorage';
 
-export const handler = pingEventMiddleware(async () => {
+export const handler = healthCheckEventMiddleware(async () => {
     RuntimeFlags.isSystemTask = true; // Flag the resources system to skip existing cache usage
 
     const externalResources = getResources('external');

--- a/src/codesets.ts
+++ b/src/codesets.ts
@@ -9,8 +9,9 @@ import { engageResourcesAction } from './app/resources-controller-actions';
 import { InternalResources } from './resources/index';
 import { resolveErrorResponse } from './utils/api';
 import { decodeBase64, parseRequestInputParams } from './utils/helpers';
-import { getStorageBucketInfo, healthCheckEventMiddleware } from './utils/runtime';
+import { getStorageBucketInfo } from './utils/runtime';
 import S3BucketStorage from './utils/services/S3BucketStorage';
+import { healthCheckEventMiddleware } from './utils/middlewares';
 
 const loggerSettings = {
     disable: {

--- a/src/utils/middlewares.ts
+++ b/src/utils/middlewares.ts
@@ -1,0 +1,23 @@
+/**
+ * Middleware to handle health-check requests
+ */
+export function healthCheckEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
+    return async function (event: any, context?: any) {
+        if (event.Records?.[0]?.cf?.request?.uri === '/health-check') {
+            return {
+                status: 200,
+                statusDescription: 'OK',
+                body: 'OK',
+                headers: {
+                    'cache-control': [
+                        {
+                            key: 'Cache-Control',
+                            value: 'max-age=0',
+                        },
+                    ],
+                },
+            };
+        }
+        return next(event, context);
+    };
+}

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -16,9 +16,21 @@ export const RuntimeFlags = {
 
 export function pingEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
     return async function (event: any, context?: any) {
-        if (event.action === 'ping') {
+        if (event.action === 'ping' || event.Records?.[0]?.cf?.request?.uri === '/health-check') {
             console.log('pong');
-            return;
+            return {
+                status: 200,
+                statusDescription: 'OK',
+                body: 'OK',
+                headers: {
+                    'cache-control': [
+                        {
+                            key: 'Cache-Control',
+                            value: 'max-age=0',
+                        },
+                    ],
+                },
+            };
         }
         return next(event, context);
     };

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -13,25 +13,3 @@ export const RuntimeFlags = {
     isLocal: false,
     isSystemTask: false,
 };
-
-export function healthCheckEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
-    return async function (event: any, context?: any) {
-        if (event.action === 'ping' || event.Records?.[0]?.cf?.request?.uri === '/health-check') {
-            console.log('pong');
-            return {
-                status: 200,
-                statusDescription: 'OK',
-                body: 'OK',
-                headers: {
-                    'cache-control': [
-                        {
-                            key: 'Cache-Control',
-                            value: 'max-age=0',
-                        },
-                    ],
-                },
-            };
-        }
-        return next(event, context);
-    };
-}

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -14,7 +14,7 @@ export const RuntimeFlags = {
     isSystemTask: false,
 };
 
-export function pingEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
+export function healthCheckEventMiddleware(next: (event: any, context?: any) => Promise<any>) {
     return async function (event: any, context?: any) {
         if (event.action === 'ping' || event.Records?.[0]?.cf?.request?.uri === '/health-check') {
             console.log('pong');


### PR DESCRIPTION
- relates to: https://github.com/Virtual-Finland-Development/monitoring/pull/36
- adds a new route `/health-check` that is ensured to run the lambda@edge-function on every request by bypassing the cloudfront cache