### PR TITLE
Fix esco-api host on local native dev-mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     working_dir: /app
     volumes:
       - .:/app
+      - ./src/build/environment.docker-compose.json:/app/src/build/environment.json
     stdin_open: true
     tty: true
     ports:

--- a/src/build/environment.docker-compose.json
+++ b/src/build/environment.docker-compose.json
@@ -1,6 +1,6 @@
 {
     "escoApi": {
-        "endpoint": "http://localhost:3560"
+        "endpoint": "http://host.docker.internal:3560"
     },
     "s3bucket": {
         "name": "",


### PR DESCRIPTION
- use localhost reference by default (for native running)
- override with docker-compose